### PR TITLE
🔔 Notify proto repository on release

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -58,6 +58,23 @@ jobs:
               }
             }
 
+  notify-proto:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update modules docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/okp4/okp4-cosmos-proto/actions/workflows/23386493/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "version": "${{ github.event.release.tag_name }}",
+              }
+            }
+
   update-docs-version:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
With the aim of automate the release of new generated proto, we need to notify the [okp4-cosmos-proto](https://github.com/okp4/okp4-cosmos-proto) repository when a new release is done on the chain, it's allow publish the latest generated proto for each language each time a new release is done on this repository. Version is align to the chain version. 