### PR TITLE
ci(publish): make docker hub publish work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         id: docker_metadata
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }},axoneprotocol/axoned
           tags: |
             type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
             type=semver,pattern={{version}}
@@ -54,30 +54,30 @@ jobs:
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
 
-#  dockerhub-description:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - name: Check out repository
-#        uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 2
-#
-#      - name: Find change in readme file
-#        id: readme-change
-#        uses: tj-actions/changed-files@v44.0.0
-#        with:
-#          files: |
-#            README.md
-#
-#      - name: Docker Hub Description
-#        if: steps.readme-change.outputs.any_changed == 'true'
-#        uses: peter-evans/dockerhub-description@v4
-#        with:
-#          username: ${{ secrets.DOCKER_HUB_REGISTRY_ID }}
-#          description: Docker image for https://github.com/okp4/okp4d
-#          password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
-#          repository: okp4/okp4d
-#          readme-filepath: README.md
+  dockerhub-description:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find change in readme file
+        id: readme-change
+        uses: tj-actions/changed-files@v44.0.0
+        with:
+          files: |
+            README.md
+
+      - name: Docker Hub Description
+        if: steps.readme-change.outputs.any_changed == 'true'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_REGISTRY_ID }}
+          description: Docker image for https://github.com/{{ .repository }}
+          password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
+          repository: axoneprotocol/axoned
+          readme-filepath: README.md
 
   publish-buf-proto:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Set the correct configuration needed to publish on the new [axoneprotocol](https://hub.docker.com/orgs/axoneprotocol/) docker hub organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker image reference and repository information for publishing.
  - Modified Docker Hub description to reflect new repository details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->