### PR TITLE
chore: add coderabbitai config to ignore generated docs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  path_filters:
+    - "!docs/command/**/*.md"
+    - "!docs/predicate/**/*.md"
+    - "!docs/proto/**/*.md"


### PR DESCRIPTION
To avoid, each time we update the commande line documentation, a coderabbitai review on generated documentation, I put a configuration to ignore those files for the review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to exclude specific Markdown files under `docs/command`, `docs/predicate`, and `docs/proto` from reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->