### PR TITLE
🐛 ci: fix notify version bump on docs

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update docs version
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/37674835/dispatches'
+          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/98246586/dispatches'
           method: 'POST'
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-


### PR DESCRIPTION
Fix [the job](https://github.com/axone-protocol/axoned/actions/runs/9178689492/job/25239152908) that notify [axone-protocol/docs](https://github.com/axone-protocol/docs) repository when a new version of [axoned](https://github.com/axone-protocol/releases) is release. 
I don't know why but the workflow id was incorrect, I guess is the migration from okp4 organisation but it's strange since the other workflow ID didn't changes.