### PR TITLE
🐛 ci: fix for incorrect versioning despite breaking changes

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -21,6 +21,8 @@ plugins:
           release: patch
         - type: docs
           release: patch
+        - breaking: true
+          release: major
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -25,7 +25,7 @@ plugins:
     - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
-      changelogTitle: "# ØKP4 protocol changelog"
+      changelogTitle: "# AXONE protocol changelog"
   - - "semantic-release-replace-plugin"
     - replacements:
         - files: [version]


### PR DESCRIPTION
This PR addresses an issue with the latest release of our project. Despite the introduction of a breaking change commit, which was correctly detected by `semantic-release` and noted in the changelog, the `major` version of the project was not incremented as expected.

This issue has been previously reported in the `semantic-release` repository ([Issue #2756](https://github.com/semantic-release/semantic-release/issues/2756)). A potential solution, as discussed in the issue [thread](https://github.com/semantic-release/semantic-release/issues/2756#issuecomment-2021671709), is to explicitly add the breaking release type in the `commit-analyzer` rules.

This PR implements this fix, ensuring that future breaking changes will correctly increment the `major` version of the project.

I also take opportunity to rename the CHANGELOG title ;) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release configuration to trigger major releases with a specific flag.
  - Changed the changelog title to "# AXONE protocol changelog".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->