### PR TITLE
🐛 ci: fix incorrect folder name for update predicate docs

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -71,7 +71,7 @@ jobs:
                 "version": "${{ github.event.release.tag_name }}",
                 "repository": "${{github.repository}}",
                 "section": "predicates",
-                "docs_directory": "docs/predicates/*"
+                "docs_directory": "docs/predicate/*"
               }
             }
 


### PR DESCRIPTION
Continuing from the previous release failure, we encountered another issue related to the [synchronization failure](https://github.com/axone-protocol/docs/actions/runs/9178693387/job/25239171883) between the `axoned` repository and the `docs` repository. This issue was caused by an incorrect path name for the predicates documentation.
