### PR TITLE
docs(predicates): grammatical correction on predicates docs

### DIFF
--- a/docs/predicate/bech32_address_2.md
+++ b/docs/predicate/bech32_address_2.md
@@ -30,7 +30,7 @@ An `Address` is a compound term `-` with two arguments, the first being the huma
 being the numeric address as a list of integers ranging from 0 to 255 representing the bytes of the address in
 base 64.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -59,7 +59,7 @@ This scenario illustrates how to decode a bech32 address into the human-readable
 The process extracts these components from a given bech32 address string, showcasing the ability to parse and
 separate the address into its constituent parts.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -89,7 +89,7 @@ answer:
 This scenario demonstrates how to extract the address from a bech32 address string, specifically for a known
 protocol, in this case, the axone protocol.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -116,7 +116,7 @@ answer:
 
 This scenario demonstrates how to encode an `Address` pair representation into a bech32 address string.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -143,7 +143,7 @@ answer:
 
 This scenario shows how to check if a bech32 address is part of the axone protocol.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the program:
 
@@ -175,7 +175,7 @@ This scenario demonstrates the system's response to an incorrect bech32 address 
 In this case, the system generates a `domain_error`, indicating that the provided argument does not meet the
 expected format for a bech32 address.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -202,7 +202,7 @@ This scenario demonstrates the system's response to an incorrect bech32 address 
 In this case, the system generates a `type_error`, indicating that the provided argument does not meet the
 expected type.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 

--- a/docs/predicate/block_height_1.md
+++ b/docs/predicate/block_height_1.md
@@ -25,7 +25,7 @@ where:
 
 This scenario demonstrates how to retrieve the block height of the current block.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** a block with the following header:
 
@@ -59,7 +59,7 @@ answer:
 This scenario demonstrates how to check that the block height is greater than 100. This predicate is useful for
 governance which requires a certain block height to be reached before a certain action is taken.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** a block with the following header:
 

--- a/docs/predicate/block_time_1.md
+++ b/docs/predicate/block_time_1.md
@@ -25,7 +25,7 @@ where:
 
 This scenario demonstrates how to retrieve the block time of the current block.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** a block with the following header:
 
@@ -60,7 +60,7 @@ This scenario demonstrates how to check that the block time is greater than 1709
 using the `block_time/1` predicate. This predicate is useful for governance which requires a certain block time to be
 reached before a certain action is taken.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** a block with the following header:
 

--- a/docs/predicate/consult_1.md
+++ b/docs/predicate/consult_1.md
@@ -30,7 +30,7 @@ This scenario demonstrates how to consult (load) a Prolog program from a CosmWas
 Assuming the existence of a CosmWasm smart contract configured to store a Prolog program, we construct a URI to specifically
 identify this smart contract and pinpoint the Prolog program we want to consult via a query message.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 
@@ -84,7 +84,7 @@ Note that the `:- multifile/1` directive is employed to enable a single predicat
 In the absence of this directive, encountering a new definition would lead the compiler to overwrite the existing
 predicate definition.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 
@@ -146,7 +146,7 @@ answer:
 
 This scenario demonstrates the consultation of several Prolog programs from different CosmWasm smart contracts.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 

--- a/docs/predicate/current_output_1.md
+++ b/docs/predicate/current_output_1.md
@@ -30,7 +30,7 @@ The outcome of the stream's content throughout the execution of a query is provi
 This scenario demonstrates how to write a character to the current output, and get the content in the response of the
 request.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the module configuration:
 
@@ -76,7 +76,7 @@ user_output: |
 This scenario demonstrates how to write some characters to the current output, and get the content in the response of the
 request. This is helpful for debugging purposes.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the module configuration:
 
@@ -124,7 +124,7 @@ user_output: |
 This scenario demonstrates the process of writing characters to the current user output, with a limit configured
 in the logic module. So if the message is longer than this limit, the output will be truncated.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the module configuration:
 
@@ -172,7 +172,7 @@ Characters such as emojis require more space; for example, the wizard emoji (ðŸ§
 as four units. As a result, the limit is reached more quickly with these characters, which means that the number of
 characters in the user output is less than expected.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the module configuration:
 

--- a/docs/predicate/open_3.md
+++ b/docs/predicate/open_3.md
@@ -32,7 +32,7 @@ purposes and obtaining the stream's properties.
 
 See the `open/4` predicate for a more detailed example.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 

--- a/docs/predicate/open_4.md
+++ b/docs/predicate/open_4.md
@@ -57,7 +57,7 @@ purposes and obtaining the stream's properties.
 Assuming the existence of a CosmWasm smart contract configured to store resources, we construct a URI to specifically
 identify the smart contract and pinpoint the resource we aim to retrieve via a query message.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 
@@ -117,7 +117,7 @@ and read its content.
 
 The resource is opened for reading, and the content is read into a list of characters. Finally, the stream is closed.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 
@@ -167,7 +167,7 @@ answer:
 This scenario is a variation of the previous one. The difference is that the smart contract returns a base64-encoded
 response. For this reason, we set the `base64Decode` parameter to `true` in the query (the default value is `false`).
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3tsrhsdrk" and the behavior:
 
@@ -216,7 +216,7 @@ answer:
 
 This scenario demonstrates the system's response to trying to open a non-existing resource.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -242,7 +242,7 @@ answer:
 This scenario demonstrates the system's response to opening a resource for writing, but the resource does not allow
 writing. This is the case for resources hosted in smart contracts which are read-only.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -268,7 +268,7 @@ answer:
 This scenario demonstrates the system's response to opening a resource for appending, but the resource does not allow
 appending. This is the case for resources hosted in smart contracts which are read-only.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 
@@ -293,7 +293,7 @@ answer:
 
 This scenario demonstrates the system's response to opening a resource with incorrect options.
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 
 - **Given** the query:
 

--- a/scripts/templates/func.go.txt
+++ b/scripts/templates/func.go.txt
@@ -23,7 +23,7 @@ sidebar_position: {{ index (index globalCtx "frontmatter") "sidebar_position" }}
 {{- spacer -}}
 {{ .Scenario.Description | dedent }}
 
-Here's the steps of the scenario:
+Here are the steps of the scenario:
 {{- spacer -}}
 {{- range .Scenario.Steps }}
 - **{{ .Keyword | trim }}** {{ .Text }}


### PR DESCRIPTION
Fix #607 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated wording in scenario descriptions from "Here's the steps" to "Here are the steps" for improved grammar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->