### PR TITLE
Improve `ErrorOutOfGas` handling in predicate execution

### DIFF
--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -142,7 +142,7 @@ func TestGRPCAsk(t *testing.T) {
 			{
 				query:         "bank_balances(X, Y).",
 				maxGas:        3000,
-				expectedError: "error executing query: out of gas in location: panic: {ValuePerByte}: out of gas: invalid argument",
+				expectedError: "out of gas: logic <panic: {ValuePerByte}> (4204/3000): limit exceeded",
 			},
 			{
 				query:  "block_height(X).",
@@ -150,7 +150,7 @@ func TestGRPCAsk(t *testing.T) {
 				predicateCosts: map[string]uint64{
 					"block_height/1": 10000,
 				},
-				expectedError: "error executing query: out of gas in location: block_height/1: out of gas: invalid argument",
+				expectedError: "out of gas: logic <block_height/1> (12353/3000): limit exceeded",
 			},
 			{
 				program: "father(bob, 'élodie').",

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -17,8 +17,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	"github.com/axone-protocol/axoned/v8/x/logic"
@@ -138,15 +140,17 @@ func TestGRPCAsk(t *testing.T) {
 				expectedError: "out of gas: logic <ReadPerByte> (1018/1000): limit exceeded",
 			},
 			{
+				query:         "bank_balances(X, Y).",
+				maxGas:        3000,
+				expectedError: "error executing query: out of gas in location: panic: {ValuePerByte}: out of gas: invalid argument",
+			},
+			{
 				query:  "block_height(X).",
 				maxGas: 3000,
 				predicateCosts: map[string]uint64{
 					"block_height/1": 10000,
 				},
-				expectedAnswer: &types.Answer{
-					Variables: []string{"X"},
-					Results:   []types.Result{{Error: "error(resource_error(gas(block_height/1,12353,3000)),block_height/1)"}},
-				},
+				expectedError: "error executing query: out of gas in location: block_height/1: out of gas: invalid argument",
 			},
 			{
 				program: "father(bob, 'élodie').",
@@ -324,6 +328,11 @@ foo(a4).
 					accountKeeper := logictestutil.NewMockAccountKeeper(ctrl)
 					bankKeeper := logictestutil.NewMockBankKeeper(ctrl)
 					fsProvider := logictestutil.NewMockFS(ctrl)
+
+					bankKeeper.EXPECT().GetAccountsBalances(gomock.Any()).Do(func(ctx gocontext.Context) []bankypes.Balance {
+						sdk.UnwrapSDKContext(ctx).GasMeter().ConsumeGas(2000, "ValuePerByte")
+						return nil
+					}).AnyTimes()
 
 					logicKeeper := keeper.NewKeeper(
 						encCfg.Codec,

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"fmt"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"io"
 	"math"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/axone-protocol/axoned/v8/x/logic/fs/filtered"
 	"github.com/axone-protocol/axoned/v8/x/logic/interpreter"

--- a/x/logic/prolog/error.go
+++ b/x/logic/prolog/error.go
@@ -2,8 +2,6 @@ package prolog
 
 import (
 	"github.com/ichiban/prolog/engine"
-
-	"cosmossdk.io/store/types"
 )
 
 var (
@@ -82,8 +80,6 @@ var (
 	// The module resource is the representation of the module with which the interaction is made.
 	// The module resource is denoted as a compound with the name of the module.
 	AtomResourceModule = engine.NewAtom("resource_module")
-	// AtomResourceGas is the atom denoting the "gas" resource.
-	AtomResourceGas = engine.NewAtom("gas")
 )
 
 // ResourceContext returns a term representing the context resource.
@@ -94,12 +90,6 @@ func ResourceContext() engine.Term {
 // ResourceModule returns a term representing the module resource with the given name.
 func ResourceModule(module string) engine.Term {
 	return AtomResourceModule.Apply(engine.NewAtom(module))
-}
-
-// ResourceGas returns a term representing the gas resource with the given descriptor, consumed and limit at the
-// given context.
-func ResourceGas(descriptor string, consumed types.Gas, limit types.Gas) engine.Term {
-	return AtomResourceGas.Apply(engine.NewAtom(descriptor), engine.Integer(int64(consumed)), engine.Integer(int64(limit)))
 }
 
 var (


### PR DESCRIPTION
Fixe #692, see issue description for complete details. 

~~**Note**: I was forced to move `QueryInterpreter` utility method into the keeper since using the common `ResourceGas` predicate error coming from keeper package lead to a cycle import between `utils` and `prolog` packages.~~

**EDIT: Now all `OutOfGas` errors that occurs in the interpreter or at predicate cost will return an GRPC error instead of a predicate prolog error.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling logic for gas consumption errors, ensuring more accurate error messages and context.
  - Enhanced test cases to cover additional scenarios related to bank balances and gas-related errors.

- **Refactor**
  - Streamlined error handling by switching from `if` statements to `switch` statements for better code readability and maintainability.
  - Removed redundant logic and unused functions to clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->