### PR TITLE
fix(gov): properly configure legacy props router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -486,7 +486,7 @@ func New(
 	)
 
 	// Set legacy router for backwards compatibility with gov v1beta1
-	app.GovKeeper.SetLegacyRouter(govRouter)
+	govKeeper.SetLegacyRouter(govRouter)
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(


### PR DESCRIPTION
At the initialisation of the governance module the legacy router responsible of executing legacy `v1beta1` proposals wasn't properly set causing the legacy proposal to be unsupported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the clarity and functionality of the `GovKeeper` assignment in the app's initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->