### PR TITLE
Align params behavior for unlimited limits

### DIFF
--- a/docs/proto/logic.md
+++ b/docs/proto/logic.md
@@ -276,8 +276,8 @@ Limits defines the limits of the logic module.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `max_size` | [string](#string) |  | max_size specifies the maximum size, in bytes, that is accepted for a program. nil value remove size limitation. |
-| `max_result_count` | [string](#string) |  | max_result_count specifies the maximum number of results that can be requested for a query. nil value remove max result count limitation. |
+| `max_size` | [string](#string) |  | max_size specifies the maximum size, in bytes, that is accepted for a program. nil value or 0 value remove size limitation. |
+| `max_result_count` | [string](#string) |  | max_result_count specifies the maximum number of results that can be requested for a query. nil value or 0 value remove max result count limitation. |
 | `max_user_output_size` | [string](#string) |  | max_user_output_size specifies the maximum number of bytes to keep in the user output. If the user output exceeds this size, the interpreter will overwrite the oldest bytes with the new ones to keep the size constant. nil value or 0 value means that no user output is used at all. |
 | `max_variables` | [string](#string) |  | max_variables specifies the maximum number of variables that can be create by the interpreter. nil value or 0 value means that no limit is set. |
 

--- a/proto/logic/v1beta2/params.proto
+++ b/proto/logic/v1beta2/params.proto
@@ -36,7 +36,7 @@ message Limits {
   option (gogoproto.goproto_stringer) = true;
 
   // max_size specifies the maximum size, in bytes, that is accepted for a program.
-  // nil value remove size limitation.
+  // nil value or 0 value remove size limitation.
   string max_size = 3 [
     (gogoproto.moretags) = "yaml:\"max_size\"",
     (gogoproto.customtype) = "cosmossdk.io/math.Uint",
@@ -44,7 +44,7 @@ message Limits {
   ];
 
   // max_result_count specifies the maximum number of results that can be requested for a query.
-  // nil value remove max result count limitation.
+  // nil value or 0 value remove max result count limitation.
   string max_result_count = 2 [
     (gogoproto.moretags) = "yaml:\"max_result_count\"",
     (gogoproto.customtype) = "cosmossdk.io/math.Uint",

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -52,13 +52,13 @@ func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (respo
 
 func checkLimits(request *types.QueryServiceAskRequest, limits types.Limits) error {
 	size := sdkmath.NewUint(uint64(len(request.GetQuery())))
-	maxSize := util.DerefOrDefault(limits.MaxSize, sdkmath.NewUint(math.MaxInt64))
+	maxSize := util.NonZeroOrDefaultUInt(limits.MaxSize, sdkmath.NewUint(math.MaxInt64))
 	if size.GT(maxSize) {
 		return errorsmod.Wrapf(types.LimitExceeded, "query: %d > MaxSize: %d", size.Uint64(), maxSize.Uint64())
 	}
 
 	resultCount := util.DerefOrDefault(request.Limit, defaultSolutionsLimit)
-	maxResultCount := util.DerefOrDefault(limits.MaxResultCount, sdkmath.NewUint(math.MaxInt64))
+	maxResultCount := util.NonZeroOrDefaultUInt(limits.MaxResultCount, sdkmath.NewUint(math.MaxInt64))
 	if resultCount.GT(maxResultCount) {
 		return errorsmod.Wrapf(types.LimitExceeded, "query: %d > MaxResultCount: %d", resultCount.Uint64(), maxResultCount.Uint64())
 	}

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -154,7 +154,7 @@ func TestGRPCAsk(t *testing.T) {
 			{
 				query:         "bank_balances(X, Y).",
 				maxGas:        3000,
-				expectedError: "out of gas: logic <panic: {ValuePerByte}> (3102/3000): limit exceeded",
+				expectedError: "out of gas: logic <panic: {ValuePerByte}> (3093/3000): limit exceeded",
 			},
 			{
 				query:  "block_height(X).",
@@ -162,7 +162,7 @@ func TestGRPCAsk(t *testing.T) {
 				predicateCosts: map[string]uint64{
 					"block_height/1": 10000,
 				},
-				expectedError: "out of gas: logic <block_height/1> (11176/3000): limit exceeded",
+				expectedError: "out of gas: logic <block_height/1> (11167/3000): limit exceeded",
 			},
 			{
 				query:         "length(List, 100000).",

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+
 	. "github.com/smartystreets/goconvey/convey"
 
 	sdkmath "cosmossdk.io/math"

--- a/x/logic/types/params.pb.go
+++ b/x/logic/types/params.pb.go
@@ -92,10 +92,10 @@ func (m *Params) GetGasPolicy() GasPolicy {
 // Limits defines the limits of the logic module.
 type Limits struct {
 	// max_size specifies the maximum size, in bytes, that is accepted for a program.
-	// nil value remove size limitation.
+	// nil value or 0 value remove size limitation.
 	MaxSize *cosmossdk_io_math.Uint `protobuf:"bytes,3,opt,name=max_size,json=maxSize,proto3,customtype=cosmossdk.io/math.Uint" json:"max_size,omitempty" yaml:"max_size"`
 	// max_result_count specifies the maximum number of results that can be requested for a query.
-	// nil value remove max result count limitation.
+	// nil value or 0 value remove max result count limitation.
 	MaxResultCount *cosmossdk_io_math.Uint `protobuf:"bytes,2,opt,name=max_result_count,json=maxResultCount,proto3,customtype=cosmossdk.io/math.Uint" json:"max_result_count,omitempty" yaml:"max_result_count"`
 	// max_user_output_size specifies the maximum number of bytes to keep in the user output. If the user output exceeds
 	// this size, the interpreter will overwrite the oldest bytes with the new ones to keep the size constant.

--- a/x/logic/util/pointer.go
+++ b/x/logic/util/pointer.go
@@ -1,6 +1,9 @@
 package util
 
-import "reflect"
+import (
+	sdkmath "cosmossdk.io/math"
+	"reflect"
+)
 
 // DerefOrDefault returns the value of the pointer if it is not nil, otherwise returns the default value.
 func DerefOrDefault[T any](ptr *T, defaultValue T) T {
@@ -15,6 +18,14 @@ func NonZeroOrDefault[T any](v, defaultValue T) T {
 	v1 := reflect.ValueOf(v)
 	if v1.IsValid() && !v1.IsZero() {
 		return v
+	}
+	return defaultValue
+}
+
+// NonZeroOrDefaultUInt returns the value of the argument if it is not nil and not zero, otherwise returns the default value.
+func NonZeroOrDefaultUInt(v *sdkmath.Uint, defaultValue sdkmath.Uint) sdkmath.Uint {
+	if v != nil && !v.IsZero() {
+		return *v
 	}
 	return defaultValue
 }

--- a/x/logic/util/pointer.go
+++ b/x/logic/util/pointer.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	sdkmath "cosmossdk.io/math"
 	"reflect"
+
+	sdkmath "cosmossdk.io/math"
 )
 
 // DerefOrDefault returns the value of the pointer if it is not nil, otherwise returns the default value.

--- a/x/logic/util/pointer_test.go
+++ b/x/logic/util/pointer_test.go
@@ -1,11 +1,12 @@
 package util
 
 import (
-	sdkmath "cosmossdk.io/math"
 	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	sdkmath "cosmossdk.io/math"
 )
 
 func TestDerefOrDefault(t *testing.T) {
@@ -63,8 +64,16 @@ func TestNonZeroOrDefaultUInt(t *testing.T) {
 			expected     sdkmath.Uint
 		}{
 			{nil, sdkmath.ZeroUint(), sdkmath.ZeroUint()},
-			{v: func() *sdkmath.Uint { u := sdkmath.ZeroUint(); return &u }(), defaultValue: sdkmath.NewUint(10), expected: sdkmath.NewUint(10)},
-			{v: func() *sdkmath.Uint { u := sdkmath.NewUint(1); return &u }(), defaultValue: sdkmath.ZeroUint(), expected: sdkmath.NewUint(1)},
+			{
+				func() *sdkmath.Uint { u := sdkmath.ZeroUint(); return &u }(),
+				sdkmath.NewUint(10),
+				sdkmath.NewUint(10),
+			},
+			{
+				func() *sdkmath.Uint { u := sdkmath.NewUint(1); return &u }(),
+				sdkmath.ZeroUint(),
+				sdkmath.NewUint(1),
+			},
 		}
 		for _, tc := range cases {
 			Convey(fmt.Sprintf("When the value is %v", tc.v), func() {

--- a/x/logic/util/pointer_test.go
+++ b/x/logic/util/pointer_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	sdkmath "cosmossdk.io/math"
 	"fmt"
 	"testing"
 
@@ -48,6 +49,27 @@ func TestNonZeroOrDefault(t *testing.T) {
 			Convey(fmt.Sprintf("When the value is %v", tc.v), func() {
 				Convey(fmt.Sprintf("Then the default value %v is returned", tc.defaultValue), func() {
 					So(NonZeroOrDefault(tc.v, tc.defaultValue), ShouldEqual, tc.expected)
+				})
+			})
+		}
+	})
+}
+
+func TestNonZeroOrDefaultUInt(t *testing.T) {
+	Convey("Given a value", t, func() {
+		cases := []struct {
+			v            *sdkmath.Uint
+			defaultValue sdkmath.Uint
+			expected     sdkmath.Uint
+		}{
+			{nil, sdkmath.ZeroUint(), sdkmath.ZeroUint()},
+			{v: func() *sdkmath.Uint { u := sdkmath.ZeroUint(); return &u }(), defaultValue: sdkmath.NewUint(10), expected: sdkmath.NewUint(10)},
+			{v: func() *sdkmath.Uint { u := sdkmath.NewUint(1); return &u }(), defaultValue: sdkmath.ZeroUint(), expected: sdkmath.NewUint(1)},
+		}
+		for _, tc := range cases {
+			Convey(fmt.Sprintf("When the value is %v", tc.v), func() {
+				Convey(fmt.Sprintf("Then the default value %v is returned", tc.defaultValue), func() {
+					So(NonZeroOrDefaultUInt(tc.v, tc.defaultValue), ShouldEqual, tc.expected)
 				})
 			})
 		}


### PR DESCRIPTION
Following [this comment](https://github.com/axone-protocol/axoned/issues/623#issuecomment-2250436495), this PR aligns the behavior for all parameters regarding the unlimited case. Most parameters are now configured to be considered unlimited if either a `nil` value or a zero value is set. I chose to align the behavior of the `max_size` and `max_result_count` parameters with this approach, as they previously did not follow the same behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new function for improved handling of pointer values in the logic module.
- **Bug Fixes**
	- Enhanced limit checks to ensure maximum size and result count values are non-zero, preventing unintended behaviors in queries.
- **Tests**
	- Introduced new test scenarios to validate the behavior of the updated limit checks and the new utility function, enhancing overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->