### PR TITLE
docs(README): fix docker-pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![build](https://img.shields.io/github/actions/workflow/status/axone-protocol/axoned/build.yml?label=build&style=for-the-badge&logo=github)](https://github.com/axone-protocol/axoned/actions/workflows/build.yml)
 [![test](https://img.shields.io/github/actions/workflow/status/axone-protocol/axoned/test.yml?label=test&style=for-the-badge&logo=github)](https://github.com/axone-protocol/axoned/actions/workflows/test.yml)
 [![codecov](https://img.shields.io/codecov/c/github/axone-protocol/axoned?style=for-the-badge&token=O3FJO5QDCA&logo=codecov)](https://codecov.io/gh/axone-protocol/axoned)
-[![docker-pull](https://img.shields.io/docker/pulls/axone-protocol/axoned?label=downloads&style=for-the-badge&logo=docker)](https://hub.docker.com/r/axone-protocol/axoned)
+[![docker-pull](https://img.shields.io/docker/pulls/axoneprotocol/axoned?label=downloads&style=for-the-badge&logo=docker)](https://hub.docker.com/r/axoneprotocol/axoned)
 [![discord](https://img.shields.io/discord/946759919678406696.svg?label=discord&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/axone)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=for-the-badge)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Self explanatory. Fixes the incorrect name used for the Docker image pulls badge.

<img width="271" alt="image" src="https://github.com/user-attachments/assets/1a645692-0603-4ed4-9201-0ef5ffde5c76">

→

<img width="171" alt="image" src="https://github.com/user-attachments/assets/4342e1d3-f17b-4daf-a528-f5c3d46b3c7f">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Docker image repository link in the README to reflect the new naming convention, ensuring users have the correct access for downloading Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->