### PR TITLE
🔐 Allow choose proof purpose when signing VC

### DIFF
--- a/client/credential/sign.go
+++ b/client/credential/sign.go
@@ -106,7 +106,6 @@ func runSignCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	documentLoader := newDocumentLoader(schemaMap)
-
 	vc, err := loadVerifiableCredential(documentLoader, bs)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerr.ErrInvalidRequest, "failed to load verifiable credential: %v", err)
@@ -119,17 +118,14 @@ func runSignCmd(cmd *cobra.Command, args []string) error {
 	if overrideProofs {
 		vc.Proofs = nil
 	}
-
 	date, err := parseStringAsDate(cmd, flagDate)
 	if err != nil {
-		return err
+		return errorsmod.Wrapf(sdkerr.ErrInvalidType, "%s is not a valid date: %v", flagDate, err)
 	}
-
 	purpose, err := cmd.Flags().GetString(flagPurpose)
 	if err != nil {
-		return err
+		return errorsmod.Wrapf(sdkerr.ErrInvalidType, "%s is not a valid string: %v", flagPurpose, err)
 	}
-
 	err = signVerifiableCredential(documentLoader, vc, signer, date, purpose)
 	if err != nil {
 		return errorsmod.Wrapf(sdkerr.ErrInvalidRequest, "failed to sign: %v", err)

--- a/client/credential/sign.go
+++ b/client/credential/sign.go
@@ -66,8 +66,8 @@ It will read a verifiable credential from a file (or stdin), sign it, and print 
 			"Multiple mappings can be provided by repeating the flag. Example usage: "+
 			"--%[1]s originalURI1=alternativeURI1 --%[1]s originalURI2=alternativeURI2",
 		flagSchemaMap))
-	cmd.Flags().String(flagPurpose, "assertionMethod", "Proof that describes credential purpose, helps prevent it from being misused for some other purpose."+
-		"Example of commonly used proof purpose values:  "+
+	cmd.Flags().String(flagPurpose, "assertionMethod", "Proof that describes credential purpose, helps prevent it from being "+
+		"misused for some other purpose. Example of commonly used proof purpose values:  "+
 		"authentication, assertionMethod, keyAgreement, capabilityDelegation, capabilityInvocation.")
 
 	_ = cmd.MarkFlagRequired(flags.FlagFrom)

--- a/docs/command/axoned_credential_sign.md
+++ b/docs/command/axoned_credential_sign.md
@@ -21,6 +21,7 @@ axoned credential sign [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --overwrite                Overwrite existing signatures with a new one. If disabled, new signature will be appended
+      --purpose string           Proof that describes credential purpose, helps prevent it from being misused for some other purpose. Example of commonly used proof purpose values:  authentication, assertionMethod, keyAgreement, capabilityDelegation, capabilityInvocation. (default "assertionMethod")
       --schema-map strings       Map original URIs to alternative URIs for resolving JSON-LD schemas. Useful for redirecting network-based URIs to local filesystem paths or other URIs. Each mapping should be in the format 'originalURI=alternativeURI'. Multiple mappings can be provided by repeating the flag. Example usage: --schema-map originalURI1=alternativeURI1 --schema-map originalURI2=alternativeURI2
 ```
 


### PR DESCRIPTION
Implements #724 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new command-line flag, `flagPurpose`, allowing users to specify the purpose of signed verifiable credentials for enhanced clarity and security.
	- Updated the credential signing process to include the purpose in the signed credential's metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->