### PR TITLE
build(docker): relax apk version constraint for git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm_muslc.
 
 # hadolint ignore=DL4006
 RUN set -eux \
-    && apk add --no-cache ca-certificates=20240226-r0 build-base=0.5-r3 git=2.40.1-r0 linux-headers=6.3-r0 \
+    && apk add --no-cache ca-certificates=20240226-r0 build-base=0.5-r3 git=~2.40 linux-headers=6.3-r0 \
     && sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 0881c5b463e89e229b06370e9e2961aec0a5c636772d5142c68d351564464a66 \
     && sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 58e1f6bfa89ee390cb9abc69a5bc126029a497fe09dd399f38a82d0d86fe95ef
 


### PR DESCRIPTION
Update the `Dockerfile` to use a flexible version constraint when installing `git` via `apk`. Now uses the latest compatible version that matches the specified major and minor version.

This fixes the docker build issue reported by the CI.

<img width="976" alt="image" src="https://github.com/user-attachments/assets/8f3d8343-600f-4f5c-b417-739769b7e342">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated the package installation command for `git` to allow for flexible versioning within the `2.40` series, enhancing package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->