### PR TITLE
⛽️ Use the default gas cost params when lookup predicate cost

### DIFF
--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -173,7 +173,9 @@ func gasMeterHookFn(ctx context.Context, gasPolicy types.GasPolicy) engine.HookF
 
 		predicate := operandStringer.String()
 
-		cost := lookupCost(predicate, defaultPredicateCost, gasPolicy.PredicateCosts)
+		cost := lookupCost(predicate,
+			nonNilNorZeroOrDefaultUint64(gasPolicy.DefaultPredicateCost, defaultPredicateCost),
+			gasPolicy.PredicateCosts)
 
 		defer func() {
 			if r := recover(); r != nil {


### PR DESCRIPTION
This pull request includes a change to the `x/logic/keeper/interpreter.go` file to improve the handling of default predicate costs in the `gasMeterHookFn` function following this issue #757 and since implementation of hooks in interpreter (#756). 

Keep the `defaultPredicateCost` const used to be the final default value in case no default cost set (nil or zero value) on module's params.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cost calculation for predicates to improve efficiency and accuracy.
  
- **Bug Fixes**
	- Fixed potential issues with default predicate cost handling when values are nil or zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->