### PR TITLE
refactor(prolog): directly import our hard fork of the prolog engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	dario.cat/mergo v1.0.1
 	github.com/CosmWasm/wasmd v0.53.0
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/axone-protocol/prolog v1.0.1-0.20241007111431-c4c18d4393b9
 	github.com/cometbft/cometbft v0.38.12
 	github.com/cosmos/cosmos-db v1.0.2
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
@@ -39,7 +40,6 @@ require (
 	github.com/hashicorp/go-metrics v0.5.3
 	github.com/huandu/xstrings v1.5.0
 	github.com/hyperledger/aries-framework-go v0.3.2
-	github.com/ichiban/prolog v1.2.0
 	github.com/ignite/cli v0.27.2
 	github.com/muesli/reflow v0.3.0
 	github.com/nuts-foundation/go-did v0.14.0
@@ -74,9 +74,6 @@ replace (
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
-
-	// Use cutom fork of prolog interpreter
-	github.com/ichiban/prolog => github.com/axone-protocol/prolog v1.0.1-0.20240930131208-a7e37dcfde82
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -292,10 +292,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.224 h1:09CiaaF35nRmxrzWZ2uRq5v6Ghg/d2RiPjZnSgtt+RQ=
 github.com/aws/aws-sdk-go v1.44.224/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/axone-protocol/prolog v1.0.1-0.20240924120526-53584b2b5c0b h1:s4U2NJBSdjZHRVOQuS2USITMFZO+Y3DuQBZagP527Q4=
-github.com/axone-protocol/prolog v1.0.1-0.20240924120526-53584b2b5c0b/go.mod h1:lbZPekEi6qr5WX29GgEmhZlTxUkeWeiJ8cZZRq8qjAE=
-github.com/axone-protocol/prolog v1.0.1-0.20240930131208-a7e37dcfde82 h1:Q9L+P3plaPoLLRUyLPYMk/HogUDoOVucInvsweOFYs0=
-github.com/axone-protocol/prolog v1.0.1-0.20240930131208-a7e37dcfde82/go.mod h1:lbZPekEi6qr5WX29GgEmhZlTxUkeWeiJ8cZZRq8qjAE=
+github.com/axone-protocol/prolog v1.0.1-0.20241007111431-c4c18d4393b9 h1:jn+ld5dI6Jfc0E9H3nELeU+CdieIzsbT+agfyyOZNuc=
+github.com/axone-protocol/prolog v1.0.1-0.20241007111431-c4c18d4393b9/go.mod h1:6jc/PgoaC+m8Zsews7MQwxlcE1nLyu28peJb4qEcve8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/x/logic/interpreter/interpreter.go
+++ b/x/logic/interpreter/interpreter.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"io/fs"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 
 	"cosmossdk.io/math"
 )

--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/predicate"

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 

--- a/x/logic/predicate/address.go
+++ b/x/logic/predicate/address.go
@@ -1,7 +1,7 @@
 package predicate
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	bech322 "github.com/cosmos/cosmos-sdk/types/bech32"
 

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"context"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/golang/mock/gomock"
-	"github.com/ichiban/prolog/engine"
 	"github.com/samber/lo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/x/logic/predicate/block.go
+++ b/x/logic/predicate/block.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"context"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/builtin_test.go
+++ b/x/logic/predicate/builtin_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/golang/mock/gomock"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/chain.go
+++ b/x/logic/predicate/chain.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"context"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/chain_test.go
+++ b/x/logic/predicate/chain_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/crypto.go
+++ b/x/logic/predicate/crypto.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"slices"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 	"github.com/axone-protocol/axoned/v10/x/logic/util"

--- a/x/logic/predicate/crypto_test.go
+++ b/x/logic/predicate/crypto_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/did.go
+++ b/x/logic/predicate/did.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"strings"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	godid "github.com/nuts-foundation/go-did/did"
 	"github.com/samber/lo"
 

--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/encoding.go
+++ b/x/logic/predicate/encoding.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"encoding/hex"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/encoding_test.go
+++ b/x/logic/predicate/encoding_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/file.go
+++ b/x/logic/predicate/file.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/io.go
+++ b/x/logic/predicate/io.go
@@ -1,6 +1,6 @@
 package predicate
 
-import "github.com/ichiban/prolog/engine"
+import "github.com/axone-protocol/prolog/engine"
 
 // CurrentOutput is a predicate that unifies the given term with the current output stream.
 //

--- a/x/logic/predicate/json.go
+++ b/x/logic/predicate/json.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	"cosmossdk.io/math"

--- a/x/logic/predicate/json_test.go
+++ b/x/logic/predicate/json_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/string.go
+++ b/x/logic/predicate/string.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/string_test.go
+++ b/x/logic/predicate/string_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/uri.go
+++ b/x/logic/predicate/uri.go
@@ -1,7 +1,7 @@
 package predicate
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/prolog"
 )

--- a/x/logic/predicate/uri_test.go
+++ b/x/logic/predicate/uri_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/ichiban/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/logic/prolog/assert.go
+++ b/x/logic/prolog/assert.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/util"

--- a/x/logic/prolog/assert_test.go
+++ b/x/logic/prolog/assert_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/x/logic/prolog/atom.go
+++ b/x/logic/prolog/atom.go
@@ -1,6 +1,6 @@
 package prolog
 
-import "github.com/ichiban/prolog/engine"
+import "github.com/axone-protocol/prolog/engine"
 
 var (
 	// AtomAs is the term used to indicate the as encoding type option.

--- a/x/logic/prolog/byte.go
+++ b/x/logic/prolog/byte.go
@@ -1,7 +1,7 @@
 package prolog
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // ByteListTermToBytes try to convert a given list of bytes into native golang []byte.

--- a/x/logic/prolog/context.go
+++ b/x/logic/prolog/context.go
@@ -3,7 +3,7 @@ package prolog
 import (
 	"context"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 

--- a/x/logic/prolog/encode.go
+++ b/x/logic/prolog/encode.go
@@ -3,7 +3,7 @@ package prolog
 import (
 	"errors"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/util"
 )

--- a/x/logic/prolog/error.go
+++ b/x/logic/prolog/error.go
@@ -1,7 +1,7 @@
 package prolog
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 var (

--- a/x/logic/prolog/hex.go
+++ b/x/logic/prolog/hex.go
@@ -3,7 +3,7 @@ package prolog
 import (
 	"encoding/hex"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // TermHexToBytes try to convert an hexadecimal encoded atom to native golang []byte.

--- a/x/logic/prolog/hex_test.go
+++ b/x/logic/prolog/hex_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/x/logic/prolog/json.go
+++ b/x/logic/prolog/json.go
@@ -1,7 +1,7 @@
 package prolog
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // JSONNull returns the compound term @(null).

--- a/x/logic/prolog/json_test.go
+++ b/x/logic/prolog/json_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/x/logic/prolog/list.go
+++ b/x/logic/prolog/list.go
@@ -1,6 +1,6 @@
 package prolog
 
-import "github.com/ichiban/prolog/engine"
+import "github.com/axone-protocol/prolog/engine"
 
 // ListHead returns the first element of the given list.
 func ListHead(list engine.Term, env *engine.Env) engine.Term {

--- a/x/logic/prolog/option.go
+++ b/x/logic/prolog/option.go
@@ -1,7 +1,7 @@
 package prolog
 
 import (
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // GetOption returns the value of the first option with the given name in the given options.

--- a/x/logic/prolog/option_test.go
+++ b/x/logic/prolog/option_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/x/logic/prolog/text.go
+++ b/x/logic/prolog/text.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // AtomToString try to convert a given atom to a string.

--- a/x/logic/prolog/tuple.go
+++ b/x/logic/prolog/tuple.go
@@ -1,6 +1,6 @@
 package prolog
 
-import "github.com/ichiban/prolog/engine"
+import "github.com/axone-protocol/prolog/engine"
 
 // Tuple is a predicate which unifies the given term with a tuple of the given arity.
 func Tuple(args ...engine.Term) engine.Term {

--- a/x/logic/prolog/unify.go
+++ b/x/logic/prolog/unify.go
@@ -1,6 +1,6 @@
 package prolog
 
-import "github.com/ichiban/prolog/engine"
+import "github.com/axone-protocol/prolog/engine"
 
 // ConvertFunc is a function mapping a domain which is a list of terms with a codomain which is a set of terms.
 // Domains and co-domains can have different cardinalities.

--- a/x/logic/testutil/logic.go
+++ b/x/logic/testutil/logic.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/interpreter/bootstrap"
 )

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/samber/lo"
 
 	errorsmod "cosmossdk.io/errors"


### PR DESCRIPTION
## Summary

Since https://github.com/axone-protocol/prolog/pull/11 we now need to base this repository on its updated module name, this is the reason of this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependency to utilize a new Prolog library, enhancing compatibility and performance.
	
- **Bug Fixes**
	- Addressed vulnerabilities by replacing outdated dependencies with more secure versions.

- **Refactor**
	- Modified import paths across multiple files to point to the new Prolog library source, ensuring consistent usage throughout the codebase.

- **Tests**
	- Adjusted test files to reference the new Prolog library, maintaining existing test logic and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->