### PR TITLE
Chore/upgrade golangci-lint to 1.61

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          version: v1.56
+          version: v1.61
 
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LEDGER_ENABLED         ?= true
 
 # Docker images
 DOCKER_IMAGE_GOLANG		  = golang:1.21-alpine3.17
-DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v1.56
+DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v1.61
 DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_IMAGE_BUF          = bufbuild/buf:1.4.0
 DOCKER_PROTO_RUN          := docker run --rm --user $(id -u):$(id -g) -v $(HOME)/.cache:/root/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)

--- a/x/logic/keeper/features_test.go
+++ b/x/logic/keeper/features_test.go
@@ -206,7 +206,7 @@ func whenTheQueryIsRun(ctx context.Context) error {
 func whenTheQueryIsRunLimitedToNSolutions(ctx context.Context, n int) error {
 	request := testCaseFromContext(ctx).request
 
-	limit := sdkmath.NewUint(uint64(n))
+	limit := sdkmath.NewUint(uint64(n)) //nolint:gosec // disable G115
 	request.Limit = &limit
 
 	testCaseFromContext(ctx).request = request

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -446,7 +446,7 @@ func TestGRPCAsk(t *testing.T) {
 
 						var limit *sdkmath.Uint
 						if tc.limit != 0 {
-							v := sdkmath.NewUint(uint64(tc.limit))
+							v := sdkmath.NewUint(uint64(tc.limit)) //nolint:gosec // disable G115
 							limit = &v
 						}
 						query := types.QueryServiceAskRequest{

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -65,7 +65,7 @@ func (k Keeper) execute(
 	}
 
 	return &types.QueryServiceAskResponse{
-		Height:     uint64(sdkCtx.BlockHeight()),
+		Height:     uint64(sdkCtx.BlockHeight()), //nolint:gosec // disable G115
 		GasUsed:    sdkCtx.GasMeter().GasConsumed(),
 		Answer:     answer,
 		UserOutput: userOutput.String(),
@@ -97,7 +97,7 @@ func (k Keeper) newInterpreter(ctx context.Context, params types.Params) (*prolo
 	var userOutputBuffer writerStringer
 	limits := params.GetLimits()
 	if limits.MaxUserOutputSize != nil && limits.MaxUserOutputSize.GT(sdkmath.ZeroUint()) {
-		userOutputBuffer = util.NewBoundedBufferMust(int(limits.MaxUserOutputSize.Uint64()))
+		userOutputBuffer = util.NewBoundedBufferMust(int(limits.MaxUserOutputSize.Uint64())) //nolint:gosec // disable G115
 	} else {
 		userOutputBuffer = new(strings.Builder)
 	}

--- a/x/logic/predicate/string.go
+++ b/x/logic/predicate/string.go
@@ -50,7 +50,7 @@ func ReadString(vm *engine.VM, stream, length, result engine.Term, cont engine.C
 
 	var maxLength uint64
 	if maxLen, ok := env.Resolve(length).(engine.Integer); ok {
-		maxLength = uint64(maxLen)
+		maxLength = uint64(maxLen) //nolint:gosec // disable G115
 	}
 
 	var builder strings.Builder
@@ -63,7 +63,7 @@ func ReadString(vm *engine.VM, stream, length, result engine.Term, cont engine.C
 			}
 			return engine.Error(engine.SyntaxError(prolog.ErrorTerm(err), env))
 		}
-		totalLen += uint64(l)
+		totalLen += uint64(l) //nolint:gosec // disable G115
 		_, err = builder.WriteRune(r)
 		if err != nil {
 			return engine.Error(engine.SyntaxError(prolog.ErrorTerm(err), env))
@@ -73,7 +73,7 @@ func ReadString(vm *engine.VM, stream, length, result engine.Term, cont engine.C
 	var r engine.Term = engine.NewAtom(builder.String())
 	return engine.Unify(
 		vm, prolog.Tuple(result, length),
-		prolog.Tuple(r, engine.Integer(totalLen)), cont, env)
+		prolog.Tuple(r, engine.Integer(totalLen)), cont, env) //nolint:gosec // disable G115
 }
 
 // StringBytes is a predicate that unifies a string with a list of bytes, returning true when the (Unicode) String is

--- a/x/logic/prolog/option.go
+++ b/x/logic/prolog/option.go
@@ -11,6 +11,7 @@ import (
 // If no option is found nil is returned.
 func GetOption(name engine.Atom, options engine.Term, env *engine.Env) (engine.Term, error) {
 	extractOption := func(opt engine.Term) (engine.Term, error) {
+		//nolint:nilnil
 		switch v := env.Resolve(opt).(type) {
 		case engine.Compound:
 			if v.Functor() == name {

--- a/x/logic/testutil/keeper_mocks.go
+++ b/x/logic/testutil/keeper_mocks.go
@@ -38,7 +38,7 @@ func MockAuthQueryServiceWithAddresses(mock *MockAuthQueryService, addresses []s
 					start = fromCursor(req.Pagination.Key)
 				}
 				if req.Pagination.Limit != 0 {
-					limit = int(req.Pagination.GetLimit())
+					limit = int(req.Pagination.GetLimit()) //nolint:gosec // disable G115
 				}
 			}
 			accounts := lo.Map(
@@ -67,7 +67,7 @@ func MockAuthQueryServiceWithAddresses(mock *MockAuthQueryService, addresses []s
 				Accounts: accounts,
 				Pagination: &query.PageResponse{
 					NextKey: lo.If(start+limit < total, toCursor(start+1)).Else(nil),
-					Total:   uint64(total),
+					Total:   uint64(total), //nolint:gosec // disable G115
 				},
 			}, nil
 		})

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -59,7 +59,7 @@ func QueryInterpreter(
 
 			var panicErr engine.PanicError
 			if errors.As(callErr, &panicErr) && errors.Is(panicErr.OriginErr, engine.ErrMaxVariables) {
-				return nil, errorsmod.Wrapf(types.LimitExceeded, panicErr.OriginErr.Error())
+				return nil, errorsmod.Wrapf(types.LimitExceeded, panicErr.OriginErr.Error()) //nolint:govet
 			}
 
 			if err = func() error {

--- a/x/mint/simulation/proposals.go
+++ b/x/mint/simulation/proposals.go
@@ -37,7 +37,7 @@ func SimulateMsgUpdateParams(r *rand.Rand, _ sdk.Context, _ []simtypes.Account) 
 	var authority sdk.AccAddress = address.Module("gov")
 
 	params := types.DefaultParams()
-	params.BlocksPerYear = uint64(simtypes.RandIntBetween(r, 1, 1000000))
+	params.BlocksPerYear = uint64(simtypes.RandIntBetween(r, 1, 1000000)) //nolint:gosec // disable G115
 	params.InflationCoef = math.LegacyNewDecWithPrec(int64(simtypes.RandIntBetween(r, 1, 100)), 2)
 	params.MintDenom = simtypes.RandStringOfLength(r, 10)
 

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -87,14 +87,14 @@ func validateInflationCoef(i interface{}) error {
 	return nil
 }
 
-func validateBounds(min, max interface{}) error {
-	vmin, ok := min.(*math.LegacyDec)
+func validateBounds(minBound, maxBound interface{}) error {
+	vmin, ok := minBound.(*math.LegacyDec)
 	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", min)
+		return fmt.Errorf("invalid parameter type: %T", minBound)
 	}
-	vmax, ok := max.(*math.LegacyDec)
+	vmax, ok := maxBound.(*math.LegacyDec)
 	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", max)
+		return fmt.Errorf("invalid parameter type: %T", maxBound)
 	}
 
 	for _, v := range []*math.LegacyDec{vmin, vmax} {
@@ -104,7 +104,7 @@ func validateBounds(min, max interface{}) error {
 	}
 
 	if vmin != nil && vmax != nil && vmin.GT(*vmax) {
-		return fmt.Errorf("inflation min cannot greater than inflation max")
+		return fmt.Errorf("inflation min cannot be greater than inflation max")
 	}
 
 	return nil

--- a/x/mint/types/params_test.go
+++ b/x/mint/types/params_test.go
@@ -1,0 +1,89 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"cosmossdk.io/math"
+)
+
+func toLegacyDec(i int64) *math.LegacyDec {
+	ii := math.LegacyNewDec(i)
+	return &ii
+}
+
+func Test_validateBounds(t *testing.T) {
+	Convey("Given test cases", t, func() {
+		cases := []struct {
+			name               string
+			minBound, maxBound interface{}
+			expectErr          bool
+			err                error
+		}{
+			{
+				name:      "validate bounds types",
+				minBound:  toLegacyDec(2),
+				maxBound:  toLegacyDec(99999999),
+				expectErr: false,
+				err:       nil,
+			},
+			{
+				name:      "validate invalid min type",
+				minBound:  2,
+				maxBound:  toLegacyDec(99999999),
+				expectErr: true,
+				err: func() error {
+					return fmt.Errorf("invalid parameter type: %T", 2)
+				}(),
+			},
+			{
+				name:      "validate invalid max type",
+				minBound:  toLegacyDec(0),
+				maxBound:  999999.0,
+				expectErr: true,
+				err: func() error {
+					return fmt.Errorf("invalid parameter type: %T", 999999.0)
+				}(),
+			},
+			{
+				name:      "validate non-negative bounds",
+				minBound:  toLegacyDec(-2),
+				maxBound:  toLegacyDec(99999999),
+				expectErr: true,
+				err: func() error {
+					return fmt.Errorf("inflation bound cannot be negative: %s", toLegacyDec(-2))
+				}(),
+			},
+			{
+				name:      "validate non-negative bounds",
+				minBound:  toLegacyDec(99999999),
+				maxBound:  toLegacyDec(1),
+				expectErr: true,
+				err: func() error {
+					return fmt.Errorf("inflation min cannot be greater than inflation max")
+				}(),
+			},
+		}
+		for nc, tc := range cases {
+			Convey(
+				fmt.Sprintf("Given test case #%d: %v, with params: %v, %v", nc, tc.name, tc.minBound, tc.maxBound), func() {
+					Convey("when validate bounds", func() {
+						err := validateBounds(tc.minBound, tc.maxBound)
+
+						if tc.expectErr {
+							Convey("then bounds validation expect error", func() {
+								So(err, ShouldNotBeNil)
+								So(err, ShouldResemble, tc.err)
+							})
+						} else {
+							Convey("then error should be nil", func() {
+								So(err, ShouldBeNil)
+							})
+						}
+					})
+				})
+		}
+	})
+}


### PR DESCRIPTION
- Upgraded golangci-lint to 1.61
- Added comments to ignore some lint warnings (in particular gosec:G115)
- Renamed min,max which are predeclared funcs as of Go 1.21
- linter `exportloopref` deprecated -- should be replaced with `copyloopvar` on upgrading to Go 1.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated Docker image version for improved linting tools.
	- Introduced a new job for linting proto files and enhanced existing linting jobs for better validation.
	- Added unit tests for validating bounds in the `validateBounds` function.

- **Bug Fixes**
	- Enhanced error handling in the `QueryInterpreter` function.

- **Documentation**
	- Added comments to suppress specific linting warnings across various functions for clarity.

- **Refactor**
	- Renamed parameters in the `validateBounds` function for better readability.
	- Minor adjustments to error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->