### PR TITLE
Fix/json float support

### DIFF
--- a/docs/predicate/json_prolog_2.md
+++ b/docs/predicate/json_prolog_2.md
@@ -7,7 +7,7 @@ sidebar_position: 15
 
 ## Description
 
-`json_prolog/2` is a predicate that will unify a JSON string into prolog terms and vice versa.
+`json_prolog/2` is a predicate that unifies a JSON into a prolog term and vice versa.
 
 The signature is as follows:
 
@@ -17,10 +17,19 @@ json_prolog(?Json, ?Term) is det
 
 Where:
 
-- Json is the string representation of the json
-- Term is an Atom that would be unified by the JSON representation as Prolog terms.
+- Json is the textual representation of the JSON, as either an atom, a list of character codes, or a list of characters.
+- Term is the Prolog term that represents the JSON structure.
 
-In addition, when passing Json and Term, this predicate return true if both result match.
+## JSON canonical representation
+
+The canonical representation for Term is:
+
+- A JSON object is mapped to a Prolog term json\(NameValueList\), where NameValueList is a list of Name\-Value pairs. Name is an atom created from the JSON string.
+- A JSON array is mapped to a Prolog list of JSON values.
+- A JSON string is mapped to a Prolog atom.
+- A JSON number is mapped to a Prolog number.
+- The JSON constants true and false are mapped to @\(true\) and @\(false\).
+- The JSON constant null is mapped to the Prolog term @\(null\).
 
 ## Examples
 

--- a/x/logic/predicate/json.go
+++ b/x/logic/predicate/json.go
@@ -23,8 +23,19 @@ import (
 //	json_prolog(?Json, ?Term) is det
 //
 // Where:
-//   - Json is the textual representation of the json, as an atom, a list of character codes, or list of characters.
-//   - Term is a term that represents the JSON in the prolog world.
+//   - Json is the textual representation of the JSON, as either an atom, a list of character codes, or a list of characters.
+//   - Term is the Prolog term that represents the JSON structure.
+//
+// # JSON canonical representation
+//
+// The canonical representation for Term is:
+//   - A JSON object is mapped to a Prolog term json(NameValueList), where NameValueList is a list of Name-Value pairs.
+//     Name is an atom created from the JSON string.
+//   - A JSON array is mapped to a Prolog list of JSON values.
+//   - A JSON string is mapped to a Prolog atom.
+//   - A JSON number is mapped to a Prolog number.
+//   - The JSON constants true and false are mapped to @(true) and @(false).
+//   - The JSON constant null is mapped to the Prolog term @(null).
 //
 // # Examples:
 //

--- a/x/logic/prolog/byte.go
+++ b/x/logic/prolog/byte.go
@@ -30,3 +30,8 @@ func BytesToByteListTerm(in []byte) engine.Term {
 	}
 	return engine.List(terms...)
 }
+
+// BytesToAtom converts a given golang []byte into an Atom.
+func BytesToAtom(in []byte) engine.Atom {
+	return engine.NewAtom(string(in))
+}

--- a/x/logic/prolog/byte_test.go
+++ b/x/logic/prolog/byte_test.go
@@ -1,0 +1,48 @@
+package prolog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/axone-protocol/prolog/engine"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBytesToAtom(t *testing.T) {
+	Convey("Given the BytesToAtom function", t, func() {
+		Convey("It should correctly convert byte slices to atoms", func() {
+			cases := []struct {
+				bytes []byte
+				want  engine.Atom
+			}{
+				{
+					bytes: []byte(""),
+					want:  engine.NewAtom(""),
+				},
+				{
+					bytes: []byte("foo bar"),
+					want:  engine.NewAtom("foo bar"),
+				},
+				{
+					bytes: []byte("こんにちは"),
+					want:  engine.NewAtom("こんにちは"),
+				},
+				{
+					bytes: []byte{0xF0, 0x9F, 0x98, 0x80},
+					want:  engine.NewAtom("😀"),
+				},
+			}
+
+			for _, tc := range cases {
+				Convey(fmt.Sprintf("When converting '%s", tc.bytes), func() {
+					got := BytesToAtom(tc.bytes)
+
+					Convey("Then the result should match the expected value", func() {
+						So(got, ShouldEqual, tc.want)
+					})
+				})
+			}
+		})
+	})
+}


### PR DESCRIPTION
This PR introduces two main features:

- Support for *floating-point numbers*: Floating-point numbers were previously missing from the implementation. Floats are now treated as the canonical representation of all numbers in JSON, using the Prolog `engine.Float` type. As the underlying type relies on [apd](https://github.com/cockroachdb/apd) -introduced in [PR #1](https://github.com/axone-protocol/prolog/pull/1)- it provides a robust mechanism for handling numbers.
- Support for the *Text* type in JSON terms: This allows the use of a list of character codes or a list of characters, in addition to atoms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON to Prolog conversion capabilities with new functions for decoding and encoding.
	- Introduced a new function to convert byte slices to Prolog atoms.
  
- **Bug Fixes**
	- Improved error handling and clarity in conversion processes for various Prolog term types.
  
- **Tests**
	- Updated and added test cases to ensure accurate validation of JSON to Prolog conversions, including handling of complex structures and numeric types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->