### PR TITLE
Ci/notify discussions release

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -4,33 +4,55 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (leave empty for last one)"
 jobs:
+  set-env:
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.set-env.outputs.tag }}
+      repo_name: ${{ steps.set-env.outputs.repo_name }}
+    steps:
+      - name: Expose tag and repo_name
+        id: set-env
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG=$(gh release view --json tagName -q '.tagName')
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          REPO_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}
+          echo "repo_name=$REPO_NAME" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+
   notify-github-discussion:
     runs-on: ubuntu-22.04
+    needs: set-env
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set ENV variables
-        run: |
-          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
 
       - name: Extract changelog for tag
         run: |
           {
             echo 'CHANGELOG<<EOF'
-            gh release view $TAG --json body -q '.body'
+            gh release view ${{ needs.set-env.outputs.tag }} --json body -q '.body'
             echo 'EOF'
           } >> "$GITHUB_ENV"
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
 
       - name: Create an announcement discussion for release
         uses: abirismyname/create-discussion@v1.2.0
         with:
-          title: 🎉 ${{ env.REPO_NAME }} ${{ github.event.release.tag_name }} released!
+          title: 🎉 ${{ needs.set-env.outputs.repo_name }} ${{ needs.set-env.outputs.tag }} released!
           body: |
-            Hey frens! [${{ github.repository }}](https://github.com/${{ github.repository }}) `${{ github.event.release.tag_name }}` just dropped! 🚀
+            Hey frens! [${{ github.repository }}](https://github.com/${{ github.repository }}) `${{ needs.set-env.outputs.tag }}` just dropped! 🚀
 
             Some fresh updates are here. Dive into the changelog and see what's cooking! 🔥
 
@@ -40,7 +62,7 @@ jobs:
 
             # Resources
 
-            📄 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}>
+            📄 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ needs.set-env.outputs.tag }}>
             🛠️ Official repo: <https://github.com/${{ github.repository }}>
             💬 Vibe with us on Discord: <${{ env.DISCORD_URL }}>
             🐦 Catch us on Twitter: <${{ env.TWITTER_URL }}>
@@ -48,13 +70,14 @@ jobs:
           category-id: ${{ env.CATEGORY_ID }}
         env:
           GH_TOKEN: ${{ secrets.OPS_TOKEN }}
-          DISCORD_URL: "https://discord.gg/axone"
-          TWITTER_URL: "https://twitter.com/axonexyz"
-          REPOSITORY_ID: "R_kgDOLsWt6A"
-          CATEGORY_ID: "DIC_kwDOLsWt6M4CemGO"
+          DISCORD_URL: ${{ vars.DISCORD_URL }}
+          TWITTER_URL: ${{ vars.TWITTER_URL }}
+          REPOSITORY_ID: ${{ vars.DISCUSSIONS_REPOSITORY_ID }}
+          CATEGORY_ID: ${{ vars.DISCUSSIONS_CATEGORY_ID }}
 
   update-docs:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Update modules docs repository
         uses: fjogeleit/http-request-action@v1
@@ -109,6 +132,7 @@ jobs:
 
   update-docs-version:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Update docs version
         uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.DISCORD_WEBHOOK }}
-          method: 'POST'
+          method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |-
             {
@@ -21,14 +21,62 @@ jobs:
               "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}"
             }
 
+  notify-github-discussion:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Extract changelog for tag
+        run: |
+          {
+            echo 'CHANGELOG<<EOF'
+            gh release view $TAG --json body -q '.body'
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
+      - name: Create an announcement discussion for release
+        uses: abirismyname/create-discussion@v1.2.0
+        with:
+          title: 🎉 ${{ env.REPO_NAME }} ${{ github.event.release.tag_name }} released!
+          body: |
+            Hey frens! [${{ github.repository }}](https://github.com/${{ github.repository }}) `${{ github.event.release.tag_name }}` just dropped! 🚀
+
+            Some fresh updates are here. Dive into the changelog and see what's cooking! 🔥
+
+            # Changelog
+
+            ${{ env.CHANGELOG }}
+
+            # Resources
+
+            📄 Changelog: <https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}>
+            🛠️ Official repo: <https://github.com/${{ github.repository }}>
+            💬 Vibe with us on Discord: <${{ env.DISCORD_URL }}>
+            🐦 Catch us on Twitter: <${{ env.TWITTER_URL }}>
+          repository-id: ${{ env.REPOSITORY_ID }}
+          category-id: ${{ env.CATEGORY_ID }}
+        env:
+          GH_TOKEN: ${{ secrets.OPS_TOKEN }}
+          DISCORD_URL: "https://discord.gg/axone"
+          TWITTER_URL: "https://twitter.com/axonexyz"
+          REPOSITORY_ID: "R_kgDOLsWt6A"
+          CATEGORY_ID: "DIC_kwDOLsWt6M4CemGO"
+
   update-docs:
     runs-on: ubuntu-22.04
     steps:
       - name: Update modules docs repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {
@@ -44,8 +92,8 @@ jobs:
       - name: Update commands docs repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {
@@ -61,8 +109,8 @@ jobs:
       - name: Update predicates docs repository
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/docs/actions/workflows/39152549/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {
@@ -81,8 +129,8 @@ jobs:
       - name: Update docs version
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/axone-protocol/docs/actions/workflows/98246586/dispatches'
-          method: 'POST'
+          url: "https://api.github.com/repos/axone-protocol/docs/actions/workflows/98246586/dispatches"
+          method: "POST"
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OPS_TOKEN }}"}'
           data: |-
             {

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -5,22 +5,6 @@ on:
     types: [published]
 
 jobs:
-  notify-discord:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Notify Discord
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: ${{ secrets.DISCORD_WEBHOOK }}
-          method: "POST"
-          customHeaders: '{"Content-Type": "application/json"}'
-          data: |-
-            {
-              "avatar_url": "https://avatars.githubusercontent.com/u/98603954?v=4",
-              "username": "Bot Anik",
-              "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}"
-            }
-
   notify-github-discussion:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Addresses https://github.com/axone-protocol/community/issues/6.

- Additionally, removes Discord notifications on release, as [GitHub Discussions](https://github.com/orgs/axone-protocol/discussions) will now serve as the primary release notification channel, with optional forwarding to Discord if needed.
- Also enables manual triggering with a specific tag input (only for the notification of release on discussions), alongside the default trigger on release. This adds flexibility for replaying the workflow when necessary.​


I manually ran the job on v10.0.0 to ensure everything works properly. You can check the result here: [axone-protocol/discussions/7](https://github.com/orgs/axone-protocol/discussions/7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced manual triggering of the release notification workflow with an optional release tag.
	- Added a new job to create discussion announcements for releases, including links to the changelog.

- **Improvements**
	- Enhanced organization of workflow jobs and steps for better efficiency.
	- Dynamic setting of documentation update versions based on the specified release tag.
	- Improved environment variable management with additional outputs for tag and repository name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->