### PR TITLE
refactor: simplify error messages in test cases

### DIFF
--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -4,7 +4,6 @@ package predicate
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/axone-protocol/prolog/engine"
@@ -36,6 +35,9 @@ import (
 )
 
 func TestBank(t *testing.T) {
+	const (
+		bench32DecodingFail = "d,e,c,o,d,i,n,g, ,b,e,c,h,3,2, ,f,a,i,l,e,d,:, ,i,n,v,a,l,i,d, ,b,e,c,h,3,2, ,s,t,r,i,n,g, ,l,e,n,g,t,h, ,3"
+	)
 	Convey("Under a mocked environment", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -173,8 +175,7 @@ func TestBank(t *testing.T) {
 				balances:   []bank.Balance{},
 				query:      `bank_balances('foo', X).`,
 				wantResult: []testutil.TermResults{{"X": "[uaxone-100]"}},
-				wantError: fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_balances/2)",
-					strings.Join(strings.Split("decoding bech32 failed: invalid bech32 string length 3", ""), ",")),
+				wantError:  fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_balances/2)", bench32DecodingFail),
 			},
 			{
 				ctx:        context.Background(),
@@ -308,8 +309,7 @@ func TestBank(t *testing.T) {
 				spendableCoins: []bank.Balance{},
 				query:          `bank_spendable_balances('foo', X).`,
 				wantResult:     []testutil.TermResults{{"X": "[uaxone-100]"}},
-				wantError: fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_spendable_balances/2)",
-					strings.Join(strings.Split("decoding bech32 failed: invalid bech32 string length 3", ""), ",")),
+				wantError:      fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_spendable_balances/2)", bench32DecodingFail),
 			},
 
 			{
@@ -453,8 +453,7 @@ func TestBank(t *testing.T) {
 				lockedCoins: []bank.Balance{},
 				query:       `bank_locked_balances('foo', X).`,
 				wantResult:  []testutil.TermResults{{"X": "[uaxone-100]"}},
-				wantError: fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_locked_balances/2)",
-					strings.Join(strings.Split("decoding bech32 failed: invalid bech32 string length 3", ""), ",")),
+				wantError:   fmt.Errorf("error(domain_error(encoding(bech32),foo),[%s],bank_locked_balances/2)", bench32DecodingFail),
 			},
 		}
 		for nc, tc := range cases {

--- a/x/logic/predicate/crypto_test.go
+++ b/x/logic/predicate/crypto_test.go
@@ -3,7 +3,6 @@ package predicate
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/axone-protocol/prolog/engine"
@@ -159,6 +158,11 @@ func TestCryptoOperations(t *testing.T) {
 }
 
 func TestXVerify(t *testing.T) {
+	const (
+		badPublicKeyLength     = "e,d,2,5,5,1,9,:, ,b,a,d, ,p,u,b,l,i,c, ,k,e,y, ,l,e,n,g,t,h,:, ,3,3"
+		failedToParsePublicKey = "f,a,i,l,e,d, ,t,o, ,p,a,r,s,e, ,c,o,m,p,r,e,s,s,e,d, ,p,u,b,l,i,c, ,k,e,y, ,(,f,i,r,s,t, ,1,0, ,b,y,t,e,s,),:, ,0,2,1,3,c,8,4,2,6,b,e,4,7,1,e,5,5,5,0,6"
+	)
+
 	Convey("Given a test cases", t, func() {
 		cases := []struct {
 			program     string
@@ -204,8 +208,7 @@ func TestXVerify(t *testing.T) {
 				eddsa_verify(PubKey, Msg, Sig, encoding(octet)).`,
 				query:       `verify.`,
 				wantSuccess: false,
-				wantError: fmt.Errorf("error(syntax_error([%s]),eddsa_verify/4)",
-					strings.Join(strings.Split("ed25519: bad public key length: 33", ""), ",")),
+				wantError:   fmt.Errorf("error(syntax_error([%s]),eddsa_verify/4)", badPublicKeyLength),
 			},
 			{ // Wrong signature
 				program: `verify :-
@@ -256,8 +259,7 @@ func TestXVerify(t *testing.T) {
 				ecdsa_verify(PubKey, Msg, Sig, encoding(octet)).`,
 				query:       `verify.`,
 				wantSuccess: false,
-				wantError: fmt.Errorf("error(syntax_error([%s]),ecdsa_verify/4)",
-					strings.Join(strings.Split("failed to parse compressed public key (first 10 bytes): 0213c8426be471e55506", ""), ",")),
+				wantError:   fmt.Errorf("error(syntax_error([%s]),ecdsa_verify/4)", failedToParsePublicKey),
 			},
 			{ // Unsupported algo
 				program: `verify :-

--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -3,7 +3,6 @@ package predicate
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/axone-protocol/prolog/engine"
@@ -23,6 +22,9 @@ import (
 )
 
 func TestDID(t *testing.T) {
+	const (
+		invalidDID = "i,n,v,a,l,i,d, ,D,I,D"
+	)
 	Convey("Given a test cases", t, func() {
 		cases := []struct {
 			program    string
@@ -79,8 +81,7 @@ func TestDID(t *testing.T) {
 			{
 				query:      `did_components('foo',X).`,
 				wantResult: []testutil.TermResults{},
-				wantError: fmt.Errorf("error(domain_error(encoding(did),foo),[%s],did_components/2)",
-					strings.Join(strings.Split("invalid DID", ""), ",")),
+				wantError:  fmt.Errorf("error(domain_error(encoding(did),foo),[%s],did_components/2)", invalidDID),
 			},
 			{
 				query:      `did_components(123,X).`,

--- a/x/logic/predicate/encoding_test.go
+++ b/x/logic/predicate/encoding_test.go
@@ -2,7 +2,6 @@ package predicate
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/axone-protocol/prolog"
@@ -23,6 +22,10 @@ import (
 )
 
 func TestHexBytesPredicate(t *testing.T) {
+	const (
+		hexEncodingErrorFmt = "e,n,c,o,d,i,n,g,/,h,e,x,:, ,i,n,v,a,l,i,d, ,b,y,t,e,:, ,U,+,0,0,6,9, ,',i,'"
+	)
+
 	Convey("Given a test cases", t, func() {
 		cases := []struct {
 			program     string
@@ -58,8 +61,7 @@ func TestHexBytesPredicate(t *testing.T) {
 			{
 				query: `hex_bytes('fail',
 				[44,38,180,107,104,255,198,143,249,155,69,60,29,48,65,52,19,66,45,112,100,131,191,160,249,138,94,136,98,102,231,174]).`,
-				wantError: fmt.Errorf("error(domain_error(encoding(hex),fail),[%s],hex_bytes/2)",
-					strings.Join(strings.Split("encoding/hex: invalid byte: U+0069 'i'", ""), ",")),
+				wantError:   fmt.Errorf("error(domain_error(encoding(hex),fail),[%s],hex_bytes/2)", hexEncodingErrorFmt),
 				wantSuccess: false,
 			},
 			{

--- a/x/logic/predicate/uri_test.go
+++ b/x/logic/predicate/uri_test.go
@@ -3,7 +3,6 @@ package predicate
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/axone-protocol/prolog/engine"
@@ -23,6 +22,9 @@ import (
 )
 
 func TestURIEncoded(t *testing.T) {
+	const (
+		invalidURLEscape = "i,n,v,a,l,i,d, ,U,R,L, ,e,s,c,a,p,e, ,\",%,%,3,\""
+	)
 	Convey("Given a test cases", t, func() {
 		cases := []struct {
 			program     string
@@ -167,8 +169,7 @@ func TestURIEncoded(t *testing.T) {
 			{
 				query:       "uri_encoded(path, Decoded, 'bar%%3foo').",
 				wantSuccess: false,
-				wantError: fmt.Errorf("error(domain_error(encoding(uri),bar%%%%3foo),[%s],uri_encoded/3)",
-					strings.Join(strings.Split("invalid URL escape \"%%3\"", ""), ",")),
+				wantError:   fmt.Errorf("error(domain_error(encoding(uri),bar%%%%3foo),[%s],uri_encoded/3)", invalidURLEscape),
 			},
 		}
 		for nc, tc := range cases {


### PR DESCRIPTION
# Pull Request: Simplify Error Messages in Test Cases

**Description**:

This pull request aims to improve the readability and maintainability of the error messages in the test cases. 

## Changes Made:
- Removed unnecessary transformations in error message strings.
- Replaced complex string manipulations with direct string literals for clarity.
- Ensured that all test cases still pass after these modifications.

## Related Issues:
- issue #771 

## Testing:
- All existing tests were run and passed successfully as much as I can see by using "make format-go & make test-go" to ensure that no functionality was broken by these changes.

## Additional Notes:
- This is my first contribution to a project on Github and try to learn Go, and I'm excited to be a part of it! I look forward to your feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error messages in various test cases for improved clarity and consistency, including handling of invalid inputs across multiple predicates (e.g., bank balances, public keys, DIDs, hex bytes, and URIs).
	- Enhanced readability of error messages by utilizing pre-defined constants instead of inline string manipulations.

These changes ensure that error messages are more straightforward, providing better context for users when issues arise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->