### PR TITLE
Switch mocking library from golang/mock to go.uber.org/mock 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ doc-predicate: ## Generate markdown documentation for all the predicates (module
 .PHONY: mock
 mock: ## Generate all the mocks (for tests)
 	@echo "${COLOR_CYAN} 🧱 Generating all the mocks${COLOR_RESET}"
-	@go install github.com/golang/mock/mockgen@v1.6.0
+	@go install go.uber.org/mock@v0.5.0
 	@mockgen -source=x/mint/types/expected_keepers.go -package testutil -destination x/mint/testutil/expected_keepers_mocks.go
 	@mockgen -source=x/vesting/types/expected_keepers.go -package testutil -destination x/vesting/testutil/expected_keepers_mocks.go
 	@mockgen -source=x/logic/types/expected_keepers.go -package testutil -destination x/logic/testutil/expected_keepers_mocks.go

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	go.uber.org/mock v0.5.0
 	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0
 	golang.org/x/net v0.30.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240814211410-ddb44dafa142
@@ -288,14 +289,14 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
-	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
+	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/api v0.171.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect

--- a/x/logic/fs/composite/fs_test.go
+++ b/x/logic/fs/composite/fs_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
 
 	"github.com/axone-protocol/axoned/v10/x/logic/fs/wasm"
 	"github.com/axone-protocol/axoned/v10/x/logic/testutil"

--- a/x/logic/fs/filtered/fs_test.go
+++ b/x/logic/fs/filtered/fs_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/fs/wasm/fs_test.go
+++ b/x/logic/fs/wasm/fs_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/keeper/features_test.go
+++ b/x/logic/keeper/features_test.go
@@ -14,9 +14,9 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/cucumber/godog"
-	"github.com/golang/mock/gomock"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/smartystreets/goconvey/convey/reporting"
+	"go.uber.org/mock/gomock"
 	"gopkg.in/yaml.v3"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -7,7 +7,7 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -6,7 +6,7 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -6,7 +6,7 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/meter/weighted_test.go
+++ b/x/logic/meter/weighted_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/x/logic/predicate/builtin_test.go
+++ b/x/logic/predicate/builtin_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/axone-protocol/prolog/engine"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/predicate/util_test.go
+++ b/x/logic/predicate/util_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/golang/mock/gomock"
+	"go.uber.org/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/x/logic/testutil/expected_keepers_mocks.go
+++ b/x/logic/testutil/expected_keepers_mocks.go
@@ -10,7 +10,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/auth/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockAccountKeeper is a mock of AccountKeeper interface.

--- a/x/logic/testutil/fs_mocks.go
+++ b/x/logic/testutil/fs_mocks.go
@@ -8,7 +8,7 @@ import (
 	fs "io/fs"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockFS is a mock of FS interface.

--- a/x/logic/testutil/gas_mocks.go
+++ b/x/logic/testutil/gas_mocks.go
@@ -7,7 +7,7 @@ package testutil
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockGasMeter is a mock of GasMeter interface.

--- a/x/logic/testutil/interface_registry_mocks.go
+++ b/x/logic/testutil/interface_registry_mocks.go
@@ -10,7 +10,7 @@ import (
 	signing "cosmossdk.io/x/tx/signing"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
 	proto "github.com/cosmos/gogoproto/proto"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 

--- a/x/logic/testutil/keeper_mocks.go
+++ b/x/logic/testutil/keeper_mocks.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/golang/mock/gomock"
 	"github.com/samber/lo"
+	"go.uber.org/mock/gomock"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/logic/testutil/read_file_fs_mocks.go
+++ b/x/logic/testutil/read_file_fs_mocks.go
@@ -8,7 +8,7 @@ import (
 	fs "io/fs"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockReadFileFS is a mock of ReadFileFS interface.

--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -3,8 +3,8 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"

--- a/x/mint/keeper/grpc_query_test.go
+++ b/x/mint/keeper/grpc_query_test.go
@@ -4,8 +4,8 @@ import (
 	gocontext "context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
 	storetypes "cosmossdk.io/store/types"
 

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -3,8 +3,8 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"

--- a/x/mint/testutil/expected_keepers_mocks.go
+++ b/x/mint/testutil/expected_keepers_mocks.go
@@ -10,7 +10,7 @@ import (
 
 	math "cosmossdk.io/math"
 	types "github.com/cosmos/cosmos-sdk/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockStakingKeeper is a mock of StakingKeeper interface.

--- a/x/vesting/msg_server_test.go
+++ b/x/vesting/msg_server_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmttime "github.com/cometbft/cometbft/types/time"

--- a/x/vesting/testutil/expected_keepers_mocks.go
+++ b/x/vesting/testutil/expected_keepers_mocks.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	types "github.com/cosmos/cosmos-sdk/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBankKeeper is a mock of BankKeeper interface.


### PR DESCRIPTION
Switch mocking library from golang/mock to go.uber.org/mock