### PR TITLE
Feat/telemetry

### DIFF
--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -106,6 +106,7 @@ func (k Keeper) newInterpreter(ctx context.Context, params types.Params) (*prolo
 			whitelistBlacklistHookFn(whitelistPredicates, blacklistPredicates),
 			gasMeterHookFn(sdkctx, params.GetGasPolicy()),
 			telemetryPredicateCallCounterHookFn(),
+			telemetryPredicateDurationHookFn(),
 		),
 		interpreter.WithPredicates(ctx, interpreter.RegistryNames),
 		interpreter.WithBootstrap(ctx, util.NonZeroOrDefault(interpreterParams.GetBootstrap(), bootstrap.Bootstrap())),

--- a/x/logic/keeper/metrics_test.go
+++ b/x/logic/keeper/metrics_test.go
@@ -1,0 +1,51 @@
+package keeper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/axone-protocol/prolog/engine"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStringifyOperand(t *testing.T) {
+	Convey("Given various inputs to stringifyOperand", t, func() {
+		testCases := []struct {
+			description string
+			input       engine.Term
+			expected    string
+			ok          bool
+		}{
+			{
+				description: "an operand implementing fmt.Stringer",
+				input:       engine.NewAtom("foo"),
+				expected:    "foo",
+				ok:          true,
+			},
+			{
+				description: "an operand not implementing fmt.Stringer",
+				input:       engine.NewAtom("foo").Apply(engine.NewAtom("bar")),
+				expected:    "",
+				ok:          false,
+			},
+			{
+				description: "the nil operand",
+				input:       nil,
+				expected:    "",
+				ok:          false,
+			},
+		}
+
+		for _, tc := range testCases {
+			Convey(fmt.Sprintf("When input is %s", tc.description), func() {
+				result, ok := stringifyOperand(tc.input)
+
+				Convey("Then the result should match the expected output", func() {
+					So(result, ShouldEqual, tc.expected)
+					So(ok, ShouldEqual, tc.ok)
+				})
+			})
+		}
+	})
+}


### PR DESCRIPTION
Adds telemetry features to the `logic` module, enabling tracking of predicate call counts and execution durations. Primarily intended for statistical data collection and limited to the node.

Ex:
```
# HELP logic_vm_predicate logic_vm_predicate
# TYPE logic_vm_predicate counter
logic_vm_predicate{predicate="chain_id/1"} 6
logic_vm_predicate{predicate="op/3"} 51
 HELP logic_vm_predicate_chain_id_1 logic_vm_predicate_chain_id_1
# TYPE logic_vm_predicate_chain_id_1 summary
logic_vm_predicate_chain_id_1{quantile="0.5"} 0.004000000189989805
logic_vm_predicate_chain_id_1{quantile="0.9"} 0.004999999888241291
logic_vm_predicate_chain_id_1{quantile="0.99"} 0.004999999888241291
logic_vm_predicate_chain_id_1_sum 0.06899999966844916
logic_vm_predicate_chain_id_1_count 6
# HELP logic_vm_predicate_op_3 logic_vm_predicate_op_3
# TYPE logic_vm_predicate_op_3 summary
logic_vm_predicate_op_3{quantile="0.5"} 0.004999999888241291
logic_vm_predicate_op_3{quantile="0.9"} 0.01600000075995922
logic_vm_predicate_op_3{quantile="0.99"} 0.210999995470047
logic_vm_predicate_op_3_sum 0.674000000115484
logic_vm_predicate_op_3_count 51
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced telemetry tracking for predicate calls, including counters and duration measurements.
	- Added new utility for converting operands to string representation for better predicate handling.

- **Bug Fixes**
	- Improved logic for checking registered predicates, streamlining permission checks.

- **Refactor**
	- Simplified predicate handling logic by replacing the previous interface with direct string conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->