### PR TITLE
Feat/expose database predicates

### DIFF
--- a/docs/predicate/abolish_1.md
+++ b/docs/predicate/abolish_1.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 1
+---
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
+
+# abolish/1
+
+## Description
+
+`abolish/1` is a predicate that abolishes a predicate from the database. Removes all clauses of the predicate designated by given predicate indicator Name/Arity.
+
+## Signature
+
+```text
+abolish(+PredicateIndicator)
+```
+
+Where:
+
+- PredicateIndicator is the indicator of the predicate to abolish.

--- a/docs/predicate/asserta_1.md
+++ b/docs/predicate/asserta_1.md
@@ -1,0 +1,178 @@
+---
+sidebar_position: 2
+---
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
+
+# asserta/1
+
+## Description
+
+`asserta/1` is a predicate that asserts a clause into the database as the first clause of the predicate.
+
+## Signature
+
+```text
+asserta(+Clause)
+```
+
+Where:
+
+- Clause is the clause to assert into the database.
+
+## Examples
+
+### Assert a fact into the database
+
+This scenario demonstrates the process of asserting a new fact into a Prolog database. In Prolog, asserting a fact means
+adding a new piece of information or *knowledge* into the database, allowing it to be referenced in subsequent queries.
+This is particularly useful when you want to dynamically extend the knowledge base with facts or rules based on conditions
+or interactions during runtime.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+assert_fact :- asserta(father(john, pete)).
+```
+
+- **Given** the query:
+
+```  prolog
+assert_fact, father(X, Y).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3977
+answer:
+  has_more: false
+  variables: ["X", "Y"]
+  results:
+  - substitutions:
+    - variable: X
+      expression: "john"
+    - variable: Y
+      expression: "pete"
+```
+
+### Only dynamic predicates can be asserted
+
+This scenario demonstrates that only dynamic predicates can be asserted. In Prolog, dynamic predicates are those that can be
+modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+parent(jane, alice).
+```
+
+- **Given** the query:
+
+```  prolog
+asserta(parent(john, alice)).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3975
+answer:
+  has_more: false
+  results:
+  - error: "error(permission_error(modify,static_procedure,parent/2),asserta/1)"
+```
+
+### Show that the fact is asserted at the beginning of the database
+
+This scenario demonstrates that the asserta/1 predicate adds the fact to the beginning of the database. This means that
+the fact is the first fact to be matched when a query is run.
+
+This is in contrast to the assertz/1 predicate, which adds the fact to the end of the database.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+:- dynamic(parent/2).
+
+parent(jane, alice).
+
+assert_fact :- asserta(parent(john, alice)).
+```
+
+- **Given** the query:
+
+```  prolog
+assert_fact, parent(X, alice).
+```
+
+- **When** the query is run (limited to 2 solutions)
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3977
+answer:
+  has_more: false
+  variables: ["X"]
+  results:
+  - substitutions:
+    - variable: X
+      expression: "john"
+  - substitutions:
+    - variable: X
+      expression: "jane"
+```
+
+### Shows a simple counter example
+
+This scenario demonstrates a simple counter example using the `asserta/1` and `retract/1` predicates.
+In this example, we represent the value of the counter as a dynamic predicate `counter/1` that is asserted and retracted
+to each time the value of the counter is incremented or decremented.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+:- dynamic(counter/1).
+
+counter(0).
+
+increment_counter :- retract(counter(X)), Y is X + 1, asserta(counter(Y)).
+decrement_counter :- retract(counter(X)), Y is X - 1, asserta(counter(Y)).
+```
+
+- **Given** the query:
+
+```  prolog
+counter(InitialValue), increment_counter, increment_counter, counter(IncrementedValue), decrement_counter, counter(DecrementedValue).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3989
+answer:
+  has_more: false
+  variables: ["InitialValue", "IncrementedValue", "DecrementedValue"]
+  results:
+  - substitutions:
+    - variable: InitialValue
+      expression: 0
+    - variable: IncrementedValue
+      expression: 2
+    - variable: DecrementedValue
+      expression: 1
+```

--- a/docs/predicate/assertz_1.md
+++ b/docs/predicate/assertz_1.md
@@ -1,0 +1,175 @@
+---
+sidebar_position: 3
+---
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
+
+# assertz/1
+
+## Description
+
+`assertz/1` is a predicate that asserts a clause into the database as the last clause of the predicate.
+
+## Signature
+
+```text
+assertz(+Clause)
+```
+
+Where:
+
+- Clause is the clause to assert into the database.
+
+## Examples
+
+### Assert a fact into the database
+
+This scenario demonstrates the process of asserting a new fact into a Prolog database. In Prolog, asserting a fact means
+adding a new piece of information or *knowledge* into the database, allowing it to be referenced in subsequent queries.
+This is particularly useful when you want to dynamically extend the knowledge base with facts or rules based on conditions
+or interactions during runtime.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+assert_fact :- assertz(father(john, pete)).
+```
+
+- **Given** the query:
+
+```  prolog
+assert_fact, father(X, Y).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3977
+answer:
+  has_more: false
+  variables: ["X", "Y"]
+  results:
+  - substitutions:
+    - variable: X
+      expression: "john"
+    - variable: Y
+      expression: "pete"
+```
+
+### Only dynamic predicates can be asserted
+
+This scenario demonstrates that only dynamic predicates can be asserted. In Prolog, dynamic predicates are those that can be
+modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+parent(jane, alice).
+```
+
+- **Given** the query:
+
+```  prolog
+assertz(parent(john, alice)).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3975
+answer:
+  has_more: false
+  results:
+  - error: "error(permission_error(modify,static_procedure,parent/2),assertz/1)"
+```
+
+### Show that the fact is asserted at the end of the database
+
+This scenario demonstrates that the assertz/1 predicate adds the fact to the end of the database. This means that
+the fact is the last fact to be matched when a query is run.
+
+This is in contrast to the asserta/1 predicate, which adds the fact to the beginning of the database.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+:- dynamic(parent/2).
+
+parent(jane, alice).
+
+assert_fact :- assertz(parent(john, alice)).
+```
+
+- **Given** the query:
+
+```  prolog
+assert_fact, parent(X, alice).
+```
+
+- **When** the query is run (limited to 2 solutions)
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3977
+answer:
+  has_more: false
+  variables: ["X"]
+  results:
+  - substitutions:
+    - variable: X
+      expression: "jane"
+  - substitutions:
+    - variable: X
+      expression: "john"
+```
+
+### Add and remove items in an inventory
+
+This scenario demonstrates how to maintain a dynamic list of items (like in an inventory system) by representing each item
+as a fact in the Prolog knowledge base. By using dynamic predicates, we can add items to the inventory and remove them on demand.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+:- dynamic(inventory/1).
+
+add_item(Item) :- assertz(inventory(Item)).
+remove_item(Item) :- retract(inventory(Item)).
+```
+
+- **And** the query:
+
+```  prolog
+add_item('apple'),
+add_item('banana'),
+add_item('orange'),
+remove_item('banana'),
+findall(I, inventory(I), CurrentInventory).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3984
+answer:
+  has_more: false
+  variables: ["I","CurrentInventory"]
+  results:
+  - substitutions:
+    - variable: CurrentInventory
+      expression: "[apple,orange]"
+```

--- a/docs/predicate/atomic_list_concat_2.md
+++ b/docs/predicate/atomic_list_concat_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/atomic_list_concat_3.md
+++ b/docs/predicate/atomic_list_concat_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 5
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/bank_balances_2.md
+++ b/docs/predicate/bank_balances_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/bank_locked_balances_2.md
+++ b/docs/predicate/bank_locked_balances_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 7
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/bank_spendable_balances_2.md
+++ b/docs/predicate/bank_spendable_balances_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 8
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/bech32_address_2.md
+++ b/docs/predicate/bech32_address_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 9
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/block_height_1.md
+++ b/docs/predicate/block_height_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 10
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/block_time_1.md
+++ b/docs/predicate/block_time_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 11
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/chain_id_1.md
+++ b/docs/predicate/chain_id_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 12
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/consult_1.md
+++ b/docs/predicate/consult_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 13
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/crypto_data_hash_3.md
+++ b/docs/predicate/crypto_data_hash_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 14
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/current_output_1.md
+++ b/docs/predicate/current_output_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 15
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/did_components_2.md
+++ b/docs/predicate/did_components_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 16
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/ecdsa_verify_4.md
+++ b/docs/predicate/ecdsa_verify_4.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 17
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/eddsa_verify_4.md
+++ b/docs/predicate/eddsa_verify_4.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 18
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/hex_bytes_2.md
+++ b/docs/predicate/hex_bytes_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 19
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/json_prolog_2.md
+++ b/docs/predicate/json_prolog_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 20
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/json_read_2.md
+++ b/docs/predicate/json_read_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 21
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/json_write_2.md
+++ b/docs/predicate/json_write_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 22
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/open_3.md
+++ b/docs/predicate/open_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 24
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/open_4.md
+++ b/docs/predicate/open_4.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 23
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/read_string_3.md
+++ b/docs/predicate/read_string_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 25
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/read_term_3.md
+++ b/docs/predicate/read_term_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 26
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/retract_1.md
+++ b/docs/predicate/retract_1.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 27
+---
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
+
+# retract/1
+
+## Description
+
+`retract/1` is a predicate that retracts a clause from the database.
+
+## Signature
+
+```text
+retract(+Clause)
+```
+
+Where:
+
+- Clause is the clause to retract from the database.
+
+## Examples
+
+### Retract a fact from the database
+
+This scenario demonstrates the process of retracting a fact from a Prolog database. In Prolog, retracting a fact means
+removing a piece of information or *knowledge* from the database, making it unavailable for subsequent queries.
+This is particularly useful when you want to dynamically remove facts or rules based on conditions or interactions
+during runtime.
+
+Here are the steps of the scenario:
+
+- **Given** the query:
+
+```  prolog
+assertz(parent(john, alice)), retract(parent(john, alice)), parent(X, Y).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3977
+answer:
+  has_more: false
+  variables: ["X","Y"]
+  results:
+```
+
+### Only dynamic predicates can be retracted
+
+This scenario demonstrates that only dynamic predicates can be retracted. In Prolog, dynamic predicates are those that can be
+modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+Here are the steps of the scenario:
+
+- **Given** the program:
+
+```  prolog
+parent(jane, alice).
+```
+
+- **Given** the query:
+
+```  prolog
+retract(parent(jane, alice)).
+```
+
+- **When** the query is run
+- **Then** the answer we get is:
+
+```  yaml
+height: 42
+gas_used: 3975
+answer:
+  has_more: false
+  results:
+  - error: "error(permission_error(modify,static_procedure,parent/2),retract/1)"
+```

--- a/docs/predicate/source_file_1.md
+++ b/docs/predicate/source_file_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 28
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/string_bytes_3.md
+++ b/docs/predicate/string_bytes_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 25
+sidebar_position: 29
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/term_to_atom_2.md
+++ b/docs/predicate/term_to_atom_2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 26
+sidebar_position: 30
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/uri_encoded_3.md
+++ b/docs/predicate/uri_encoded_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 27
+sidebar_position: 31
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/predicate/write_term_3.md
+++ b/docs/predicate/write_term_3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 28
+sidebar_position: 32
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/x/logic/keeper/features/asserta_1.feature
+++ b/x/logic/keeper/features/asserta_1.feature
@@ -91,3 +91,40 @@ Feature: asserta/1
           - variable: X
             expression: "jane"
       """
+
+  @great_for_documentation
+  Scenario: Shows a simple counter example.
+    This scenario demonstrates a simple counter example using the `asserta/1` and `retract/1` predicates.
+    In this example, we represent the value of the counter as a dynamic predicate `counter/1` that is asserted and retracted
+    to each time the value of the counter is incremented or decremented.
+
+    Given the program:
+      """ prolog
+      :- dynamic(counter/1).
+
+      counter(0).
+
+      increment_counter :- retract(counter(X)), Y is X + 1, asserta(counter(Y)).
+      decrement_counter :- retract(counter(X)), Y is X - 1, asserta(counter(Y)).
+      """
+    Given the query:
+      """ prolog
+      counter(InitialValue), increment_counter, increment_counter, counter(IncrementedValue), decrement_counter, counter(DecrementedValue).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3989
+      answer:
+        has_more: false
+        variables: ["InitialValue", "IncrementedValue", "DecrementedValue"]
+        results:
+        - substitutions:
+          - variable: InitialValue
+            expression: 0
+          - variable: IncrementedValue
+            expression: 2
+          - variable: DecrementedValue
+            expression: 1
+      """

--- a/x/logic/keeper/features/asserta_1.feature
+++ b/x/logic/keeper/features/asserta_1.feature
@@ -1,0 +1,93 @@
+Feature: asserta/1
+  This feature is to test the asserta/1 predicate.
+
+  @great_for_documentation
+  Scenario: Assert a fact into the database.
+    This scenario demonstrates the process of asserting a new fact into a Prolog database. In Prolog, asserting a fact means
+    adding a new piece of information or *knowledge* into the database, allowing it to be referenced in subsequent queries.
+    This is particularly useful when you want to dynamically extend the knowledge base with facts or rules based on conditions
+    or interactions during runtime.
+
+    Given the program:
+      """ prolog
+      assert_fact :- asserta(father(john, pete)).
+      """
+    Given the query:
+      """ prolog
+      assert_fact, father(X, Y).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3977
+      answer:
+        has_more: false
+        variables: ["X", "Y"]
+        results:
+        - substitutions:
+          - variable: X
+            expression: "john"
+          - variable: Y
+            expression: "pete"
+      """
+
+  @great_for_documentation
+  Scenario: Only dynamic predicates can be asserted.
+    This scenario demonstrates that only dynamic predicates can be asserted. In Prolog, dynamic predicates are those that can be
+    modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+    Given the program:
+      """ prolog
+      parent(jane, alice).
+      """
+    Given the query:
+      """ prolog
+      asserta(parent(john, alice)).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3975
+      answer:
+        has_more: false
+        results:
+        - error: "error(permission_error(modify,static_procedure,parent/2),asserta/1)"
+      """
+
+  @great_for_documentation
+  Scenario: Show that the fact is asserted at the beginning of the database.
+    This scenario demonstrates that the asserta/1 predicate adds the fact to the beginning of the database. This means that
+    the fact is the first fact to be matched when a query is run.
+
+    This is in contrast to the assertz/1 predicate, which adds the fact to the end of the database.
+
+    Given the program:
+      """ prolog
+      :- dynamic(parent/2).
+
+      parent(jane, alice).
+
+      assert_fact :- asserta(parent(john, alice)).
+      """
+    Given the query:
+      """ prolog
+      assert_fact, parent(X, alice).
+      """
+    When the query is run (limited to 2 solutions)
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3977
+      answer:
+        has_more: false
+        variables: ["X"]
+        results:
+        - substitutions:
+          - variable: X
+            expression: "john"
+        - substitutions:
+          - variable: X
+            expression: "jane"
+      """

--- a/x/logic/keeper/features/assertz_1.feature
+++ b/x/logic/keeper/features/assertz_1.feature
@@ -1,0 +1,93 @@
+Feature: assertz/1
+  This feature is to test the assertz/1 predicate.
+
+  @great_for_documentation
+  Scenario: Assert a fact into the database.
+    This scenario demonstrates the process of asserting a new fact into a Prolog database. In Prolog, asserting a fact means
+    adding a new piece of information or *knowledge* into the database, allowing it to be referenced in subsequent queries.
+    This is particularly useful when you want to dynamically extend the knowledge base with facts or rules based on conditions
+    or interactions during runtime.
+
+    Given the program:
+      """ prolog
+      assert_fact :- assertz(father(john, pete)).
+      """
+    Given the query:
+      """ prolog
+      assert_fact, father(X, Y).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3977
+      answer:
+        has_more: false
+        variables: ["X", "Y"]
+        results:
+        - substitutions:
+          - variable: X
+            expression: "john"
+          - variable: Y
+            expression: "pete"
+      """
+
+  @great_for_documentation
+  Scenario: Only dynamic predicates can be asserted.
+    This scenario demonstrates that only dynamic predicates can be asserted. In Prolog, dynamic predicates are those that can be
+    modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+    Given the program:
+      """ prolog
+      parent(jane, alice).
+      """
+    Given the query:
+      """ prolog
+      assertz(parent(john, alice)).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3975
+      answer:
+        has_more: false
+        results:
+        - error: "error(permission_error(modify,static_procedure,parent/2),assertz/1)"
+      """
+
+  @great_for_documentation
+  Scenario: Show that the fact is asserted at the end of the database.
+    This scenario demonstrates that the assertz/1 predicate adds the fact to the end of the database. This means that
+    the fact is the last fact to be matched when a query is run.
+
+    This is in contrast to the asserta/1 predicate, which adds the fact to the beginning of the database.
+
+    Given the program:
+      """ prolog
+      :- dynamic(parent/2).
+
+      parent(jane, alice).
+
+      assert_fact :- assertz(parent(john, alice)).
+      """
+    Given the query:
+      """ prolog
+      assert_fact, parent(X, alice).
+      """
+    When the query is run (limited to 2 solutions)
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3977
+      answer:
+        has_more: false
+        variables: ["X"]
+        results:
+        - substitutions:
+          - variable: X
+            expression: "jane"
+        - substitutions:
+          - variable: X
+            expression: "john"
+      """

--- a/x/logic/keeper/features/assertz_1.feature
+++ b/x/logic/keeper/features/assertz_1.feature
@@ -91,3 +91,37 @@ Feature: assertz/1
           - variable: X
             expression: "john"
       """
+
+@great_for_documentation
+Scenario: Add and remove items in an inventory.
+  This scenario demonstrates how to maintain a dynamic list of items (like in an inventory system) by representing each item
+  as a fact in the Prolog knowledge base. By using dynamic predicates, we can add items to the inventory and remove them on demand.
+
+  Given the program:
+    """ prolog
+    :- dynamic(inventory/1).
+
+    add_item(Item) :- assertz(inventory(Item)).
+    remove_item(Item) :- retract(inventory(Item)).
+    """
+  And the query:
+    """ prolog
+    add_item('apple'),
+    add_item('banana'),
+    add_item('orange'),
+    remove_item('banana'),
+    findall(I, inventory(I), CurrentInventory).
+    """
+  When the query is run
+  Then the answer we get is:
+    """ yaml
+    height: 42
+    gas_used: 3984
+    answer:
+      has_more: false
+      variables: ["I","CurrentInventory"]
+      results:
+      - substitutions:
+        - variable: CurrentInventory
+          expression: "[apple,orange]"
+    """

--- a/x/logic/keeper/features/retract_1.feature
+++ b/x/logic/keeper/features/retract_1.feature
@@ -1,0 +1,48 @@
+Feature: retract/1
+  This feature is to test the retract/1 predicate.
+
+  @great_for_documentation
+  Scenario: Retract a fact from the database.
+    This scenario demonstrates the process of retracting a fact from a Prolog database. In Prolog, retracting a fact means
+    removing a piece of information or *knowledge* from the database, making it unavailable for subsequent queries.
+    This is particularly useful when you want to dynamically remove facts or rules based on conditions or interactions
+    during runtime.
+
+    Given the query:
+      """ prolog
+      assertz(parent(john, alice)), retract(parent(john, alice)), parent(X, Y).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3977
+      answer:
+        has_more: false
+        variables: ["X","Y"]
+        results:
+      """
+
+  @great_for_documentation
+  Scenario: Only dynamic predicates can be retracted.
+    This scenario demonstrates that only dynamic predicates can be retracted. In Prolog, dynamic predicates are those that can be
+    modified during runtime. This is in contrast to static predicates, which are fixed and cannot be modified.
+
+    Given the program:
+      """ prolog
+      parent(jane, alice).
+      """
+    Given the query:
+      """ prolog
+      retract(parent(jane, alice)).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 3975
+      answer:
+        has_more: false
+        results:
+        - error: "error(permission_error(modify,static_procedure,parent/2),retract/1)"
+      """

--- a/x/logic/predicate/database.go
+++ b/x/logic/predicate/database.go
@@ -1,0 +1,52 @@
+package predicate
+
+import "github.com/axone-protocol/prolog/engine"
+
+// Asserta is a predicate that asserts a clause into the database as the first clause of the predicate.
+//
+// # Signature
+//
+//	asserta(+Clause)
+//
+// Where:
+//   - Clause is the clause to assert into the database.
+func Asserta(vm *engine.VM, clause engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Asserta(vm, clause, cont, env)
+}
+
+// Assertz is a predicate that asserts a clause into the database as the last clause of the predicate.
+//
+// # Signature
+//
+//	assertz(+Clause)
+//
+// Where:
+//   - Clause is the clause to assert into the database.
+func Assertz(vm *engine.VM, clause engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Assertz(vm, clause, cont, env)
+}
+
+// Retract is a predicate that retracts a clause from the database.
+//
+// # Signature
+//
+//	retract(+Clause)
+//
+// Where:
+//   - Clause is the clause to retract from the database.
+func Retract(vm *engine.VM, clause engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Retract(vm, clause, cont, env)
+}
+
+// Abolish is a predicate that abolishes a predicate from the database.
+// Removes all clauses of the predicate designated by given predicate indicator Name/Arity.
+//
+// # Signature
+//
+//	abolish(+PredicateIndicator)
+//
+// Where:
+//   - PredicateIndicator is the indicator of the predicate to abolish.
+func Abolish(vm *engine.VM, indicator engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Abolish(vm, indicator, cont, env)
+}


### PR DESCRIPTION
Expose the ISO predicates related to “database” management, specifically those used for handling dynamic predicates. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced features for `asserta/1`, `assertz/1`, and `retract/1` predicates in Prolog, with multiple scenarios demonstrating their functionality.
	- Scenarios include asserting facts, handling dynamic vs. static predicates, and managing an inventory system.
- **Bug Fixes**
	- Improved error handling for attempts to assert or retract static predicates.
- **Documentation**
	- Comprehensive test cases and expected outputs for new features to enhance user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->