### PR TITLE
Build/summarise tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           go-version: "1.23"
 
+      - name: Restore Cache for Tools
+        uses: actions/cache@v3
+        with:
+          path: ./target/tools
+          key: tools-cache-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
       - name: Test go project
         run: |
           make test-go

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ The project comes with a convenient `Makefile` that helps you to build, install,
 $ make <target>
 
 Targets:
-  Lint:
     lint                Lint all available linters
     lint-go             Lint go source code
     lint-proto          Lint proto files
@@ -120,7 +119,7 @@ Targets:
     chain-init          Initialize the blockchain with default settings.
     chain-start         Start the blockchain with existing configuration (see chain-init)
     chain-stop          Stop the blockchain
-    chain-upgrade       Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION. You can pass also the proposal json file on PROPOSAL var
+    chain-upgrade       Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION.
   Clean:
     clean               Remove all the files from the target folder
   Proto:
@@ -135,6 +134,9 @@ Targets:
     mock                Generate all the mocks (for tests)
   Release:
     release-assets      Generate release assets
+  Dependencies:
+    deps                Install all the dependencies (tools, etc.)
+    deps-tparse         Install tparse v0.16.0 (github.com/mfridman/tparse@v0.16.0)
   Help:
     help                Show this help.
 


### PR DESCRIPTION
This PR updates the `test-go` Makefile target to provide a summary of go test results using the amazing [tparse](https://arc.net/l/quote/frycoues) tool. The tool is automatically installed by the Makefile if it is not already available or if a different version is required.

<img width="850" alt="image" src="https://github.com/user-attachments/assets/e771b4c4-0abf-4de5-9bd1-60cdd5bb0bf7">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new section in the README for "Dependencies," detailing necessary tools and dependencies for the project.
	- Introduced a new target `deps` in the Makefile for installing essential tools.

- **Bug Fixes**
	- Simplified the description for the `chain-upgrade` target in the README to enhance clarity.

- **Chores**
	- Updated workflow configuration for caching tools in the `test-go` job to improve efficiency during testing.
	- Integrated the `tparse` tool into the testing process for better test result processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->