### PR TITLE
Test/more panic err

### DIFF
--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -181,6 +181,13 @@ func TestGRPCAsk(t *testing.T) {
 				expectedError: "maximum number of variables reached: limit exceeded",
 			},
 			{
+				program:       "l(L) :- length(L, 1). l(L) :- length(L, 1000).",
+				query:         "l(L).",
+				limit:         2,
+				maxVariables:  1000,
+				expectedError: "maximum number of variables reached: limit exceeded",
+			},
+			{
 				program: "father(bob, 'élodie').",
 				query:   "father(bob, X).",
 				expectedAnswer: &types.Answer{

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -64,7 +64,7 @@ func QueryInterpreter(
 
 			var err engine.Exception
 			if errors.As(callErr, &err) {
-				if err, ok := isPanicError(err.Term(), env); ok {
+				if err, ok := isPanicError(err.Term()); ok {
 					return nil, errorsmod.Wrapf(types.LimitExceeded, "%s", err)
 				}
 			}
@@ -147,7 +147,8 @@ func isBound(v engine.ParsedVariable, env *engine.Env) bool {
 }
 
 // isPanicError returns the panic error message if the given term is a panic_error.
-func isPanicError(term engine.Term, env *engine.Env) (string, bool) {
+func isPanicError(term engine.Term) (string, bool) {
+	var env *engine.Env
 	if env, ok := env.Unify(term, errPanicError); ok {
 		return fmt.Sprintf("%s", env.Resolve(errMessageVar)), true
 	}


### PR DESCRIPTION
Use an isolated env when unifying panic errors with error template (prevents unintended side effects). Come with an additional test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test case for the `Ask` method to validate behavior with specific Prolog-like queries.
  
- **Bug Fixes**
	- Enhanced error handling for nil queries in the `Ask` method, ensuring appropriate error messages are returned.
  
- **Refactor**
	- Simplified the `isPanicError` function by removing unnecessary parameters and streamlining error handling in the `QueryInterpreter` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->