### PR TITLE
build(project): enforce go module deps immutability in install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ $(ENVIRONMENTS_TARGETS):
 .PHONY: install
 install: ## Install node executable
 	@echo "${COLOR_CYAN} 🚚 Installing project ${BINARY_NAME}${COLOR_RESET}"
-	@go install ${BUILD_FLAGS} ${CMD_ROOT}
+	@go install -mod=readonly ${BUILD_FLAGS} ${CMD_ROOT}
 
 ## Test:
 .PHONY: test


### PR DESCRIPTION
Add the `-mod=readonly` flag when running the `go install` command, ensuring the module dependencies are not modified during installation.