### PR TITLE
Build/heighliner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build go project
         run: |
-          make build
+          make build-go
 
   build-docker:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install AXONE blockchain
         run: |
-          make build && make install
+          make build-go && make install
 
       - name: Initialize blockchain
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN set -eux \
 
 COPY . /src/
 
-RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build
+RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build-go
 
 #--- Image stage
 FROM alpine:3.20.3

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,15 @@ DOCKER_IMAGE_MARKDOWNLINT = thegeeklab/markdownlint-cli:0.32.2
 DOCKER_IMAGE_GOTEMPLATE   = hairyhenderson/gomplate:v3.11.3-alpine
 
 # Tools
-TOOL_TPARSE_NAME    := tparse
-TOOL_TPARSE_VERSION := v0.16.0
-TOOL_TPARSE_PKG     := github.com/mfridman/$(TOOL_TPARSE_NAME)@$(TOOL_TPARSE_VERSION)
-TOOL_TPARSE_BIN     := ${TOOLS_FOLDER}/$(TOOL_TPARSE_NAME)/$(TOOL_TPARSE_VERSION)/$(TOOL_TPARSE_NAME)
+TOOL_TPARSE_NAME         := tparse
+TOOL_TPARSE_VERSION      := v0.16.0
+TOOL_TPARSE_PKG          := github.com/mfridman/$(TOOL_TPARSE_NAME)@$(TOOL_TPARSE_VERSION)
+TOOL_TPARSE_BIN          := ${TOOLS_FOLDER}/$(TOOL_TPARSE_NAME)/$(TOOL_TPARSE_VERSION)/$(TOOL_TPARSE_NAME)
+
+TOOL_HEIGHLINER_NAME     := heighliner
+TOOL_HEIGHLINER_VERSION  := v1.7.1
+TOOL_HEIGHLINER_PKG      := github.com/strangelove-ventures/$(TOOL_HEIGHLINER_NAME)@$(TOOL_HEIGHLINER_VERSION)
+TOOL_HEIGHLINER_BIN      := ${TOOLS_FOLDER}/$(TOOL_HEIGHLINER_NAME)/$(TOOL_HEIGHLINER_VERSION)/$(TOOL_HEIGHLINER_NAME)
 
 # Some colors (if supported)
 define get_color
@@ -429,15 +434,32 @@ ensure-buildx-builder:
 
 ## Dependencies:
 .PHONY: deps
-deps: deps-$(TOOL_TPARSE_NAME) ## Install all the dependencies (tools, etc.)
+deps: deps-$(TOOL_TPARSE_NAME) deps-$(TOOL_HEIGHLINER_NAME) ## Install all the dependencies (tools, etc.)
 
 .PHONY: deps-$(TOOL_TPARSE_NAME)
 deps-tparse: $(TOOL_TPARSE_BIN) ## Install $TOOL_TPARSE_NAME $TOOL_TPARSE_VERSION ($TOOL_TPARSE_PKG)
+
+.PHONY: deps-$(TOOL_HEIGHLINER_NAME)
+deps-heighliner: $(TOOL_HEIGHLINER_BIN) ## Install $TOOL_HEIGHLINER_NAME $TOOL_HEIGHLINER_VERSION ($TOOL_HEIGHLINER_PKG)
 
 $(TOOL_TPARSE_BIN):
 	@echo "${COLOR_CYAN} 📦 Installing ${COLOR_GREEN}$(TOOL_TPARSE_NAME)@$(TOOL_TPARSE_VERSION)${COLOR_CYAN}...${COLOR_RESET}"
 	@mkdir -p $(dir $(TOOL_TPARSE_BIN))
 	@GOBIN=$(dir $(abspath $(TOOL_TPARSE_BIN))) go install $(TOOL_TPARSE_PKG)
+
+$(TOOL_HEIGHLINER_BIN):
+	@echo "${COLOR_CYAN} 📦 Installing ${COLOR_GREEN}$(TOOL_HEIGHLINER_NAME)@$(TOOL_HEIGHLINER_VERSION)${COLOR_CYAN}...${COLOR_RESET}"
+	@mkdir -p $(dir $(TOOL_HEIGHLINER_BIN))
+	CUR_DIR=$(shell pwd) && \
+	TEMP_DIR=$(shell mktemp -d) && \
+	GIT_URL=https://$(firstword $(subst @, ,$(TOOL_HEIGHLINER_PKG))).git && \
+	GIT_TAG=$(word 2,$(subst @, ,$(TOOL_HEIGHLINER_PKG))) && \
+	git clone --branch $$GIT_TAG --depth 1 $$GIT_URL $$TEMP_DIR && \
+	cd $$TEMP_DIR && \
+	make build && \
+	cd $$CUR_DIR && \
+	mv $$TEMP_DIR/heighliner $(TOOL_HEIGHLINER_BIN) && \
+	rm -rf $$TEMP_DIR
 
 ## Help:
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Targets:
     build               Build all available artefacts (executable, docker image, etc.)
     build-go            Build node executable for the current environment (default build)
     build-go-all        Build node executables for all available environments
+    build-docker        Build docker image
   Install:
     install             Install node executable
   Test:
@@ -137,6 +138,7 @@ Targets:
   Dependencies:
     deps                Install all the dependencies (tools, etc.)
     deps-tparse         Install tparse v0.16.0 (github.com/mfridman/tparse@v0.16.0)
+    deps-heighliner     Install heighliner v1.7.1 (github.com/strangelove-ventures/heighliner@v1.7.1)
   Help:
     help                Show this help.
 
@@ -148,13 +150,22 @@ This Makefile depends on docker. To install it, please follow the instructions:
 
 ### Build
 
-To build the `axoned` node, invoke the goal `build` of the `Makefile`:
+To build the `axoned` node, invoke the goal `build-go` of the `Makefile`:
 
 ```sh
-make build
+make build-go
 ```
 
 The binary will be generated under the folder `target/dist`.
+
+### Build a docker image
+
+This project leverages [heighliner](https://github.com/strangelove-ventures/heighliner) to simplify the management and
+creation of production-grade container images. To build a Docker image, use the `build-docker` target in the `Makefile`:
+
+```sh
+make build-docker
+```
 
 ### Run a local network
 


### PR DESCRIPTION
Introduces `Docker` image builds using [Heighliner](https://github.com/strangelove-ventures/heighliner), following the addition of `axone`  chain support in [heighliner#299](https://github.com/strangelove-ventures/heighliner/pull/299).