### PR TITLE
Ci/codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = *.pulsar.go,*.pb.go,*.pb.gw.go,*.json,*.git,*.bin,*.sum,*.mod,CHANGELOG.md,./docs
+count = true
+quiet-level = 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -233,3 +233,18 @@ jobs:
           version: "v0.9.0"
         env:
           SHELLCHECK_OPTS: -e SC2034
+
+  lint-typos:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install codespell
+        run: |
+          pip install codespell==2.3.0
+
+      - name: Check for spelling errors
+        run: |
+          codespell --config .codespellrc
+          exit $?

--- a/cmd/axoned/cmd/genaccount_test.go
+++ b/cmd/axoned/cmd/genaccount_test.go
@@ -64,7 +64,7 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 		},
 		{
 			name:        "with keyring",
-			addr:        "ser",
+			addr:        "ser", // codespell:ignore
 			denom:       "1000atom",
 			withKeyring: true,
 			expectErr:   false,

--- a/docs/command/axoned_tx_vesting_create-permanent-locked-account.md
+++ b/docs/command/axoned_tx_vesting_create-permanent-locked-account.md
@@ -5,7 +5,7 @@ Create a new permanently locked account funded with an allocation of tokens.
 ### Synopsis
 
 Create a new account funded with an allocation of permanently locked tokens. These
-tokens may be used for staking but are non-transferable. Staking rewards will acrue as liquid and transferable
+tokens may be used for staking but are non-transferable. Staking rewards will accrue as liquid and transferable
 tokens.
 
 ```

--- a/starship/tests/setup_test.go
+++ b/starship/tests/setup_test.go
@@ -17,7 +17,7 @@ func TestE2ETestSuite(t *testing.T) {
 }
 
 func (s *TestSuite) TestChainsStatus() {
-	s.T().Log("runing test for /status endpoint for each chain")
+	s.T().Log("running test for /status endpoint for each chain")
 
 	for _, chainClient := range s.chainClients {
 		status, err := chainClient.GetStatus()
@@ -40,7 +40,7 @@ func (s *TestSuite) TestChainTokenTransfer() {
 
 	s.TransferTokens(chain1, address, 2345000, denom)
 
-	// Verify the address recived the token
+	// Verify the address received the token
 	balance, err := chain1.Client.QueryBalanceWithDenomTraces(context.Background(), sdk.MustAccAddressFromBech32(address), nil)
 	s.Require().NoError(err)
 
@@ -60,10 +60,10 @@ func (s *TestSuite) TestChainIBCTransfer() {
 	address, err := chain1.CreateRandWallet(keyName)
 	s.Require().NoError(err)
 
-	// Tranfer atom to axone chain
+	// Transfer atom to axone chain
 	s.IBCTransferTokens(chain2, chain1, address, 12345000)
 
-	// Verify the address recived the token
+	// Verify the address received the token
 	balances, err := banktypes.NewQueryClient(chain1.Client).AllBalances(context.Background(), &banktypes.QueryAllBalancesRequest{
 		Address: address,
 	})

--- a/x/logic/fs/wasm/fs.go
+++ b/x/logic/fs/wasm/fs.go
@@ -112,7 +112,7 @@ func (f *vfs) parsePath(op string, path string) (sdk.AccAddress, string, bool, e
 	pathsLen := len(paths)
 	if pathsLen < 1 || paths[pathsLen-1] == "" {
 		return nil, "", false,
-			&fs.PathError{Op: op, Path: path, Err: fmt.Errorf("emtpy path given, should be '%s:{contractName}:{contractAddr}?query={query}'",
+			&fs.PathError{Op: op, Path: path, Err: fmt.Errorf("empty path given, should be '%s:{contractName}:{contractAddr}?query={query}'",
 				Scheme)}
 	}
 

--- a/x/logic/fs/wasm/fs_test.go
+++ b/x/logic/fs/wasm/fs_test.go
@@ -99,7 +99,7 @@ func TestWasmVFS(t *testing.T) {
 				data:            []byte("\"hey\""),
 				uri:             `cosmwasm:?query=%7B%22object_data%22%3A%7B%22id%22%3A%20%224cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05%22%7D%7D`,
 				wantResult:      []byte("\"\""),
-				wantError:       fmt.Sprintf("cosmwasm:?query=%%7B%%22object_data%%22%%3A%%7B%%22id%%22%%3A%%20%%224cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05%%22%%7D%%7D: emtpy path given, should be 'cosmwasm:{contractName}:{contractAddr}?query={query}'"),
+				wantError:       fmt.Sprintf("cosmwasm:?query=%%7B%%22object_data%%22%%3A%%7B%%22id%%22%%3A%%20%%224cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05%%22%%7D%%7D: empty path given, should be 'cosmwasm:{contractName}:{contractAddr}?query={query}'"),
 			},
 			{
 				contractAddress: contractAddress,

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -679,13 +679,13 @@ func TestAccount(t *testing.T) {
 				addresses: []string{
 					"axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa",
 				},
-				query: `account(unparseable).`,
+				query: `account(unparsable).`,
 				wantAnswer: &types.Answer{
 					HasMore:   false,
 					Variables: []string{},
 					Results: []types.Result{
 						{
-							Error:         "error(domain_error(encoding(bech32),unparseable),[d,e,c,o,d,i,n,g, ,b,e,c,h,3,2, ,f,a,i,l,e,d,:, ,i,n,v,a,l,i,d, ,s,e,p,a,r,a,t,o,r, ,i,n,d,e,x, ,-,1],account/1)",
+							Error:         "error(domain_error(encoding(bech32),unparsable),[d,e,c,o,d,i,n,g, ,b,e,c,h,3,2, ,f,a,i,l,e,d,:, ,i,n,v,a,l,i,d, ,s,e,p,a,r,a,t,o,r, ,i,n,d,e,x, ,-,1],account/1)",
 							Substitutions: nil,
 						},
 					},
@@ -695,13 +695,13 @@ func TestAccount(t *testing.T) {
 				addresses: []string{
 					"axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa",
 				},
-				query: `account("wrong agument type").`,
+				query: `account("wrong argument type").`,
 				wantAnswer: &types.Answer{
 					HasMore:   false,
 					Variables: []string{},
 					Results: []types.Result{
 						{
-							Error:         "error(type_error(atom,[w,r,o,n,g, ,a,g,u,m,e,n,t, ,t,y,p,e]),account/1)",
+							Error:         "error(type_error(atom,[w,r,o,n,g, ,a,r,g,u,m,e,n,t, ,t,y,p,e]),account/1)",
 							Substitutions: nil,
 						},
 					},

--- a/x/logic/prolog/assert_test.go
+++ b/x/logic/prolog/assert_test.go
@@ -169,7 +169,7 @@ func TestWhitelistBlacklistMatches(t *testing.T) {
 
 		for nc, tc := range cases {
 			Convey(
-				fmt.Sprintf("Given test case #%d with values: %v cheked against whitelist: %v and blacklist: %v",
+				fmt.Sprintf("Given test case #%d with values: %v checked against whitelist: %v and blacklist: %v",
 					nc, tc.values, tc.whitelist, tc.blacklist), func() {
 					Convey("When the function WhitelistBlacklistMatches() is called", func() {
 						result := lo.Filter(tc.values, util.Indexed(util.WhitelistBlacklistMatches(tc.whitelist, tc.blacklist, tc.predicate)))

--- a/x/vesting/client/cli/tx.go
+++ b/x/vesting/client/cli/tx.go
@@ -100,7 +100,7 @@ func NewMsgCreatePermanentLockedAccountCmd(ac address.Codec) *cobra.Command {
 		Use:   "create-permanent-locked-account [to_address] [amount]",
 		Short: "Create a new permanently locked account funded with an allocation of tokens.",
 		Long: `Create a new account funded with an allocation of permanently locked tokens. These
-tokens may be used for staking but are non-transferable. Staking rewards will acrue as liquid and transferable
+tokens may be used for staking but are non-transferable. Staking rewards will accrue as liquid and transferable
 tokens.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Introduces [codespell](https://github.com/codespell-project/codespell) as a _linter_ in the CI pipeline to detect and prevent common misspellings (text and source code files).