### PR TITLE
fix typo: "lean" to "learn"

### DIFF
--- a/cmd/axoned/cmd/root.go
+++ b/cmd/axoned/cmd/root.go
@@ -84,7 +84,7 @@ Axone is a public dPoS layer 1 specifically designed for connecting, sharing, an
 It is an open network dedicated to collaborative AI workflow management that is universally compatible with any data, model,
 or infrastructure. Data, algorithms, storage, compute, APIs... Anything on-chain and off-chain can be shared.
 
-Want to lean more about AXONE network? Complete documentation is available at: https://docs.axone.xyz 👀
+Want to learn more about AXONE network? Complete documentation is available at: https://docs.axone.xyz 👀
 `,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// set the default command outputs

--- a/docs/command/axoned.md
+++ b/docs/command/axoned.md
@@ -8,7 +8,7 @@ Axone is a public dPoS layer 1 specifically designed for connecting, sharing, an
 It is an open network dedicated to collaborative AI workflow management that is universally compatible with any data, model,
 or infrastructure. Data, algorithms, storage, compute, APIs... Anything on-chain and off-chain can be shared.
 
-Want to lean more about AXONE network? Complete documentation is available at: [https://docs.axone.xyz](https://docs.axone.xyz)  👀
+Want to learn more about AXONE network? Complete documentation is available at: [https://docs.axone.xyz](https://docs.axone.xyz)  👀
 
 ### Options
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI help text for AXONE by correcting a typo (“lean” → “learn”). Users will see the improved wording in --help output and command descriptions, offering clearer guidance. No behavioral changes; all commands and options remain unchanged. This polish enhances readability and professionalism, reducing potential confusion for first-time users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->