### PR TITLE
fix typo

### DIFF
--- a/docs/command/axoned_comet_version.md
+++ b/docs/command/axoned_comet_version.md
@@ -4,7 +4,7 @@ Print CometBFT libraries' version
 
 ### Synopsis
 
-Print protocols' and libraries' version numbers against which this app has been compiled.
+Print protocols and libraries' version numbers against which this app has been compiled.
 
 ```
 axoned comet version [flags]


### PR DESCRIPTION
No need for the apostrophe in "protocols" as it is not possessive.