### PR TITLE
Feat/configurable wasm size

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -590,11 +590,7 @@ func New(
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))
 	}
 
-	if MaxWasmSize != "" {
-		if wasmtypes.MaxWasmSize, err = strconv.Atoi(MaxWasmSize); err != nil {
-			panic(fmt.Sprintf("error while parsing MaxWasmSize: %s", err))
-		}
-	}
+	mustConfigureWasmExtensionPoints()
 
 	var wasmOpts []wasmkeeper.Option
 	if cast.ToBool(appOpts.Get("telemetry.enabled")) {
@@ -917,6 +913,15 @@ func New(
 	}
 
 	return app
+}
+
+func mustConfigureWasmExtensionPoints() {
+	var err error
+	if MaxWasmSize != "" {
+		if wasmtypes.MaxWasmSize, err = strconv.Atoi(MaxWasmSize); err != nil {
+			panic(fmt.Sprintf("error while parsing MaxWasmSize: %s", err))
+		}
+	}
 }
 
 func (app *App) setAnteHandler(txConfig client.TxConfig, wasmConfig wasmtypes.WasmConfig, txCounterStoreKey *storetypes.KVStoreKey) {

--- a/app/app.go
+++ b/app/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -170,6 +171,11 @@ var (
 		ibcfeetypes.ModuleName:         nil,
 		wasmtypes.ModuleName:           {authtypes.Burner},
 	}
+
+	// MaxWasmSize defines the maximum allowed size (in bytes) for uploaded Wasm code.
+	// This parameter can be set at compile time.
+	// More details: https://github.com/CosmWasm/wasmd/blob/main/README.md#compile-time-parameters
+	MaxWasmSize string
 )
 
 var _ servertypes.Application = (*App)(nil)
@@ -582,6 +588,12 @@ func New(
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))
+	}
+
+	if MaxWasmSize != "" {
+		if wasmtypes.MaxWasmSize, err = strconv.Atoi(MaxWasmSize); err != nil {
+			panic(fmt.Sprintf("error while parsing MaxWasmSize: %s", err))
+		}
 	}
 
 	var wasmOpts []wasmkeeper.Option

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMaxWasmSizeParsing(t *testing.T) {
+	const defaultMaxWasmSize = 42
+
+	Convey("Given a test cases", t, func() {
+		cases := []struct {
+			name          string
+			maxWasmSize   string
+			expectedPanic bool
+			expectedValue int
+		}{
+			{"empty string", "", false, defaultMaxWasmSize},
+			{"valid number", "1048576", false, 1048576},
+			{"invalid input", "not-a-number", true, defaultMaxWasmSize},
+		}
+
+		Convey(fmt.Sprintf("With default MaxWasmSize set to %d", defaultMaxWasmSize), func() {
+			wasmtypes.MaxWasmSize = defaultMaxWasmSize
+
+			for _, tc := range cases {
+				Convey(fmt.Sprintf("When MaxWasmSize is '%s'", tc.maxWasmSize), func() {
+					MaxWasmSize = tc.maxWasmSize
+
+					Convey("Calling initialization should match expectations", func() {
+						if tc.expectedPanic {
+							So(mustConfigureWasmExtensionPoints, ShouldPanic)
+						} else {
+							mustConfigureWasmExtensionPoints()
+							So(wasmtypes.MaxWasmSize, ShouldEqual, tc.expectedValue)
+						}
+					})
+
+					Reset(func() {
+						wasmtypes.MaxWasmSize = defaultMaxWasmSize
+					})
+				})
+			}
+		})
+	})
+}


### PR DESCRIPTION
This PR introduces a compile-time configuration for the [`MaxWasmSize`](https://github.com/CosmWasm/wasmd/blob/main/README.md#compile-time-parameters) parameter, which defines the maximum size for smart contracts that can be deployed on the [Axone](https://axone.xyz) chain.

To improve flexibility and anticipate future [smart contract](https://github.com/axone-protocol/contracts) changes, this limit is now set at `1MB` during build time (previously `800KB`), allowing for larger contract deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved build output now dynamically displays the application version.
  - Added a configurable maximum WebAssembly upload size with built‐in validation to enforce file size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->