### PR TITLE
Ci/golangci lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          version: v1.61
+          version: v2.0
 
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-run:
-  timeout: 10m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -17,17 +15,14 @@ linters:
     - exhaustive
     - forbidigo
     - funlen
-    - gci
     - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - goimports
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -43,71 +38,88 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - stylecheck
     - tagliatelle
-    - tenv
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - wastedassign
     - whitespace
-
-linters-settings:
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - blank # blank imports
-      - dot # dot imports
-      - prefix(github.com/cometbft/cometbft) # comet
-      - prefix(cosmossdk.io) # cosmossdk.io
-      - prefix(github.com/cosmos/cosmos-sdk) # cosmos-sdk & cosmos org libs
-      - prefix(github.com/cosmos/interchain-security) # interchain-security
-      - prefix(github.com/cosmos/ibc-go) # ibc
-      - prefix(github.com/axone-protocol/axoned) # axone
-    custom-order: true
-
-  cyclop:
-    max-complexity: 20
-    skip-tests: true
-  funlen:
-    statements: 65
-  godot:
-    scope: declarations # comments to be checked: `declarations` (default), `toplevel`, or `all`
-  lll:
-    line-length: 135
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: snake
-        yaml: snake
-output:
-  uniq-by-line: false
-
+  settings:
+    cyclop:
+      max-complexity: 20
+    funlen:
+      statements: 65
+    godot:
+      scope: declarations
+    lll:
+      line-length: 135
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+        use-field-name: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: ^//\s*go:generate\s
+      - linters:
+          - godot
+        source: (noinspection|TODO)
+      - linters:
+          - gocritic
+        source: //noinspection
+      - linters:
+          - errorlint
+        source: ^\s+if _, ok := err\.\([^.]+\.InternalError\); ok {
+      - linters:
+          - dupl
+          - funlen
+        path: _test\.go
+      - linters:
+          - revive
+        path: _test\.go
+        text: "dot-imports:"
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - source: "^//\\s*go:generate\\s"
-      linters:
-        - lll
-    - source: "(noinspection|TODO)"
-      linters:
-        - godot
-    - source: "//noinspection"
-      linters:
-        - gocritic
-    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
-      linters:
-        - errorlint
-    - path: "_test\\.go"
-      linters:
-        - dupl
-        - funlen
-    - path: "_test\\.go"
-      linters:
-        - revive
-      text: "dot-imports:"
+  uniq-by-line: false
+formatters:
+  enable:
+    - gci
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - blank
+        - dot
+        - prefix(github.com/cometbft/cometbft)
+        - prefix(cosmossdk.io)
+        - prefix(github.com/cosmos/cosmos-sdk)
+        - prefix(github.com/cosmos/interchain-security)
+        - prefix(github.com/cosmos/ibc-go)
+        - prefix(github.com/axone-protocol/axoned)
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LEDGER_ENABLED         ?= true
 
 # Docker images
 DOCKER_IMAGE_GOLANG	      = golang:1.23-alpine3.20
-DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v1.61
+DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v2.0
 DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_IMAGE_BUF          = bufbuild/buf:1.4.0
 DOCKER_PROTO_RUN         := docker run --rm --user $(id -u):$(id -g) -v $(HOME)/.cache:/root/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)

--- a/app/app.go
+++ b/app/app.go
@@ -441,7 +441,7 @@ func New(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		app.AccountKeeper.AddressCodec(),
 	)
-	app.BaseApp.SetCircuitBreaker(&app.CircuitKeeper)
+	app.SetCircuitBreaker(&app.CircuitKeeper)
 
 	groupConfig := group.DefaultConfig()
 	/*
@@ -904,7 +904,7 @@ func New(
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(err.Error())
 		}
-		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+		ctx := app.NewUncachedContext(true, tmproto.Header{})
 
 		// Initialize pinned codes in wasmvm as they are not persisted there
 		if err := app.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
@@ -1136,7 +1136,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, _ config.APIConfig) {
 
 // RegisterTxService implements the Application.RegisterTxService method.
 func (app *App) RegisterTxService(clientCtx client.Context) {
-	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.BaseApp.Simulate, app.interfaceRegistry)
+	authtx.RegisterTxService(app.GRPCQueryRouter(), clientCtx, app.Simulate, app.interfaceRegistry)
 }
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
@@ -1144,7 +1144,7 @@ func (app *App) RegisterTendermintService(clientCtx client.Context) {
 	cmtApp := server.NewCometABCIWrapper(app)
 	cmtservice.RegisterTendermintService(
 		clientCtx,
-		app.BaseApp.GRPCQueryRouter(),
+		app.GRPCQueryRouter(),
 		app.interfaceRegistry,
 		cmtApp.Query,
 	)

--- a/app/export.go
+++ b/app/export.go
@@ -52,7 +52,7 @@ func (app *App) ExportAppStateAndValidators(
 		AppState:        appState,
 		Validators:      validators,
 		Height:          height,
-		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
+		ConsensusParams: app.GetConsensusParams(ctx),
 	}, nil
 }
 
@@ -63,12 +63,8 @@ func (app *App) ExportAppStateAndValidators(
 //
 //nolint:funlen,gocognit,gocyclo,cyclop
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
-	applyAllowedAddrs := false
-
 	// check if there is a allowed address list
-	if len(jailAllowedAddrs) > 0 {
-		applyAllowedAddrs = true
-	}
+	applyAllowedAddrs := len(jailAllowedAddrs) > 0
 
 	allowedAddrsMap := make(map[string]bool)
 

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -14,7 +14,7 @@ import (
 
 func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (response *types.QueryServiceAskResponse, err error) {
 	if req == nil {
-		return nil, errorsmod.Wrap(types.InvalidArgument, "request is nil")
+		return nil, errorsmod.Wrap(types.ErrInvalidArgument, "request is nil")
 	}
 
 	sdkCtx := withSafeGasMeter(sdk.UnwrapSDKContext(ctx))
@@ -22,7 +22,7 @@ func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (respo
 		if r := recover(); r != nil {
 			if gasError, ok := r.(storetypes.ErrorOutOfGas); ok {
 				response, err = nil, errorsmod.Wrapf(
-					types.LimitExceeded, "out of gas: %s <%s> (%d/%d)",
+					types.ErrLimitExceeded, "out of gas: %s <%s> (%d/%d)",
 					types.ModuleName, gasError.Descriptor, sdkCtx.GasMeter().GasConsumed(), sdkCtx.GasMeter().Limit())
 
 				return
@@ -49,7 +49,7 @@ func checkLimits(request *types.QueryServiceAskRequest, limits types.Limits) err
 	size := uint64(len(request.GetQuery()))
 
 	if limits.MaxSize != 0 && size > limits.MaxSize {
-		return errorsmod.Wrapf(types.LimitExceeded, "query: %d > MaxSize: %d", size, limits.MaxSize)
+		return errorsmod.Wrapf(types.ErrLimitExceeded, "query: %d > MaxSize: %d", size, limits.MaxSize)
 	}
 
 	return nil

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -52,10 +52,10 @@ func (k Keeper) execute(
 
 	i, userOutput, err := k.newInterpreter(ctx, params)
 	if err != nil {
-		return nil, errorsmod.Wrapf(types.Internal, "error creating interpreter: %v", err.Error())
+		return nil, errorsmod.Wrapf(types.ErrInternal, "error creating interpreter: %v", err.Error())
 	}
 	if err := i.ExecContext(ctx, program); err != nil {
-		return nil, errorsmod.Wrapf(types.InvalidArgument, "error compiling query: %v", err.Error())
+		return nil, errorsmod.Wrapf(types.ErrInvalidArgument, "error compiling query: %v", err.Error())
 	}
 
 	answer, err := k.queryInterpreter(ctx, i, query, calculateSolutionLimit(solutionsLimit, params.GetLimits().MaxResultCount))
@@ -183,7 +183,7 @@ func gasMeterHookFn(ctx context.Context, gasPolicy types.GasPolicy) engine.HookF
 				switch rType := r.(type) {
 				case storetypes.ErrorOutOfGas:
 					err = errorsmod.Wrapf(
-						types.LimitExceeded, "out of gas: %s <%s> (%d/%d)",
+						types.ErrLimitExceeded, "out of gas: %s <%s> (%d/%d)",
 						types.ModuleName, rType.Descriptor, sdkctx.GasMeter().GasConsumed(), sdkctx.GasMeter().Limit())
 				default:
 					panic(r)

--- a/x/logic/types/errors.go
+++ b/x/logic/types/errors.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	InvalidArgument = sdkerrors.RegisterWithGRPCCode(ModuleName, 1, codes.InvalidArgument, "invalid argument")
+	ErrInvalidArgument = sdkerrors.RegisterWithGRPCCode(ModuleName, 1, codes.InvalidArgument, "invalid argument")
 	// LimitExceeded is returned when a limit is exceeded.
-	LimitExceeded = sdkerrors.RegisterWithGRPCCode(ModuleName, 2, codes.InvalidArgument, "limit exceeded")
+	ErrLimitExceeded = sdkerrors.RegisterWithGRPCCode(ModuleName, 2, codes.InvalidArgument, "limit exceeded")
 	// Internal is returned when an internal error occurs.
-	Internal = sdkerrors.RegisterWithGRPCCode(ModuleName, 3, codes.Internal, "internal error")
+	ErrInternal = sdkerrors.RegisterWithGRPCCode(ModuleName, 3, codes.Internal, "internal error")
 )

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -35,7 +35,7 @@ func QueryInterpreter(
 	p := engine.NewParser(&i.VM, strings.NewReader(query))
 	t, err := p.Term()
 	if err != nil {
-		return nil, errorsmod.Wrapf(types.InvalidArgument, "error executing query: %v", err.Error())
+		return nil, errorsmod.Wrapf(types.ErrInvalidArgument, "error executing query: %v", err.Error())
 	}
 
 	var env *engine.Env
@@ -52,20 +52,20 @@ func QueryInterpreter(
 	vars := parsedVarsToVars(p.Vars)
 	results, err := envsToResults(envs, p.Vars, i)
 	if err != nil {
-		return nil, errorsmod.Wrapf(types.InvalidArgument, "error executing query: %v", err.Error())
+		return nil, errorsmod.Wrapf(types.ErrInvalidArgument, "error executing query: %v", err.Error())
 	}
 
 	if callErr != nil {
 		if uint64(len(results)) < solutionsLimit {
 			// error is not part of the look-ahead and should be included in the solutions
-			if errors.Is(callErr, types.LimitExceeded) {
+			if errors.Is(callErr, types.ErrLimitExceeded) {
 				return nil, callErr
 			}
 
 			var err engine.Exception
 			if errors.As(callErr, &err) {
 				if err, ok := isPanicError(err.Term()); ok {
-					return nil, errorsmod.Wrapf(types.LimitExceeded, "%s", err)
+					return nil, errorsmod.Wrapf(types.ErrLimitExceeded, "%s", err)
 				}
 			}
 
@@ -76,7 +76,7 @@ func QueryInterpreter(
 				sdkCtx := sdk.UnwrapSDKContext(ctx)
 				if sdkCtx.GasMeter().IsOutOfGas() {
 					return errorsmod.Wrapf(
-						types.LimitExceeded, "out of gas: %s <%s> (%d/%d)",
+						types.ErrLimitExceeded, "out of gas: %s <%s> (%d/%d)",
 						types.ModuleName, callErr.Error(), sdkCtx.GasMeter().GasConsumed(), sdkCtx.GasMeter().Limit())
 				}
 				return nil

--- a/x/mint/module_test.go
+++ b/x/mint/module_test.go
@@ -26,7 +26,7 @@ func TestItCreatesModuleAccountOnInitBlock(t *testing.T) {
 		), &accountKeeper)
 	require.NoError(t, err)
 
-	ctx := app.BaseApp.NewContext(false)
+	ctx := app.NewContext(false)
 	acc := accountKeeper.GetAccount(ctx, authtypes.NewModuleAddress(types.ModuleName))
 	require.NotNil(t, acc)
 }

--- a/x/vesting/msg_server.go
+++ b/x/vesting/msg_server.go
@@ -52,20 +52,20 @@ func (s msgServer) CreateVestingAccount(goCtx context.Context,
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	if err := s.BankKeeper.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
+	if err := s.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
 		return nil, err
 	}
 
-	if s.BankKeeper.BlockedAddr(to) {
+	if s.BlockedAddr(to) {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
 	}
 
-	if acc := s.AccountKeeper.GetAccount(ctx, to); acc != nil {
+	if acc := s.GetAccount(ctx, to); acc != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account %s already exists", msg.ToAddress)
 	}
 
 	baseAccount := authtypes.NewBaseAccountWithAddress(to)
-	baseAccount = s.AccountKeeper.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
+	baseAccount = s.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
 	baseVestingAccount, err := types.NewBaseVestingAccount(baseAccount, msg.Amount.Sort(), msg.EndTime)
 	if err != nil {
 		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
@@ -78,7 +78,7 @@ func (s msgServer) CreateVestingAccount(goCtx context.Context,
 		vestingAccount = types.NewContinuousVestingAccountRaw(baseVestingAccount, ctx.BlockTime().Unix())
 	}
 
-	s.AccountKeeper.SetAccount(ctx, vestingAccount)
+	s.SetAccount(ctx, vestingAccount)
 
 	defer func() {
 		telemetry.IncrCounter(1, "new", "account")
@@ -94,7 +94,7 @@ func (s msgServer) CreateVestingAccount(goCtx context.Context,
 		}
 	}()
 
-	if err = s.BankKeeper.SendCoins(ctx, from, to, msg.Amount); err != nil {
+	if err = s.SendCoins(ctx, from, to, msg.Amount); err != nil {
 		return nil, err
 	}
 
@@ -119,26 +119,26 @@ func (s msgServer) CreatePermanentLockedAccount(goCtx context.Context,
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	if err := s.BankKeeper.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
+	if err := s.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
 		return nil, err
 	}
 
-	if s.BankKeeper.BlockedAddr(to) {
+	if s.BlockedAddr(to) {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
 	}
 
-	if acc := s.AccountKeeper.GetAccount(ctx, to); acc != nil {
+	if acc := s.GetAccount(ctx, to); acc != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account %s already exists", msg.ToAddress)
 	}
 
 	baseAccount := authtypes.NewBaseAccountWithAddress(to)
-	baseAccount = s.AccountKeeper.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
+	baseAccount = s.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
 	vestingAccount, err := types.NewPermanentLockedAccount(baseAccount, msg.Amount)
 	if err != nil {
 		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
 
-	s.AccountKeeper.SetAccount(ctx, vestingAccount)
+	s.SetAccount(ctx, vestingAccount)
 
 	defer func() {
 		telemetry.IncrCounter(1, "new", "account")
@@ -154,7 +154,7 @@ func (s msgServer) CreatePermanentLockedAccount(goCtx context.Context,
 		}
 	}()
 
-	if err = s.BankKeeper.SendCoins(ctx, from, to, msg.Amount); err != nil {
+	if err = s.SendCoins(ctx, from, to, msg.Amount); err != nil {
 		return nil, err
 	}
 
@@ -193,27 +193,27 @@ func (s msgServer) CreatePeriodicVestingAccount(goCtx context.Context,
 		totalCoins = totalCoins.Add(period.Amount...)
 	}
 
-	if s.BankKeeper.BlockedAddr(to) {
+	if s.BlockedAddr(to) {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	if acc := s.AccountKeeper.GetAccount(ctx, to); acc != nil {
+	if acc := s.GetAccount(ctx, to); acc != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account %s already exists", msg.ToAddress)
 	}
 
-	if err := s.BankKeeper.IsSendEnabledCoins(ctx, totalCoins...); err != nil {
+	if err := s.IsSendEnabledCoins(ctx, totalCoins...); err != nil {
 		return nil, err
 	}
 
 	baseAccount := authtypes.NewBaseAccountWithAddress(to)
-	baseAccount = s.AccountKeeper.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
+	baseAccount = s.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
 	vestingAccount, err := types.NewPeriodicVestingAccount(baseAccount, totalCoins.Sort(), msg.StartTime, msg.VestingPeriods)
 	if err != nil {
 		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
 
-	s.AccountKeeper.SetAccount(ctx, vestingAccount)
+	s.SetAccount(ctx, vestingAccount)
 
 	defer func() {
 		telemetry.IncrCounter(1, "new", "account")
@@ -229,7 +229,7 @@ func (s msgServer) CreatePeriodicVestingAccount(goCtx context.Context,
 		}
 	}()
 
-	if err = s.BankKeeper.SendCoins(ctx, from, to, totalCoins); err != nil {
+	if err = s.SendCoins(ctx, from, to, totalCoins); err != nil {
 		return nil, err
 	}
 
@@ -262,20 +262,20 @@ func (s msgServer) CreateCliffVestingAccount(goCtx context.Context,
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	if err := s.BankKeeper.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
+	if err := s.IsSendEnabledCoins(ctx, msg.Amount...); err != nil {
 		return nil, err
 	}
 
-	if s.BankKeeper.BlockedAddr(to) {
+	if s.BlockedAddr(to) {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
 	}
 
-	if acc := s.AccountKeeper.GetAccount(ctx, to); acc != nil {
+	if acc := s.GetAccount(ctx, to); acc != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account %s already exists", msg.ToAddress)
 	}
 
 	baseAccount := authtypes.NewBaseAccountWithAddress(to)
-	baseAccount = s.AccountKeeper.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
+	baseAccount = s.NewAccount(ctx, baseAccount).(*authtypes.BaseAccount)
 	baseVestingAccount, err := types.NewBaseVestingAccount(baseAccount, msg.Amount.Sort(), msg.EndTime)
 	if err != nil {
 		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
@@ -283,7 +283,7 @@ func (s msgServer) CreateCliffVestingAccount(goCtx context.Context,
 
 	vestingAccount := types.NewCliffVestingAccountRaw(baseVestingAccount, ctx.BlockTime().Unix(), msg.CliffTime)
 
-	s.AccountKeeper.SetAccount(ctx, vestingAccount)
+	s.SetAccount(ctx, vestingAccount)
 
 	defer func() {
 		telemetry.IncrCounter(1, "new", "account")
@@ -299,7 +299,7 @@ func (s msgServer) CreateCliffVestingAccount(goCtx context.Context,
 		}
 	}()
 
-	if err = s.BankKeeper.SendCoins(ctx, from, to, msg.Amount); err != nil {
+	if err = s.SendCoins(ctx, from, to, msg.Amount); err != nil {
 		return nil, err
 	}
 

--- a/x/vesting/types/vesting_account.go
+++ b/x/vesting/types/vesting_account.go
@@ -234,7 +234,7 @@ func (cva ContinuousVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coi
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (cva ContinuousVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return cva.BaseVestingAccount.LockedCoinsFromVesting(cva.GetVestingCoins(blockTime))
+	return cva.LockedCoinsFromVesting(cva.GetVestingCoins(blockTime))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -343,7 +343,7 @@ func (pva PeriodicVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (pva PeriodicVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return pva.BaseVestingAccount.LockedCoinsFromVesting(pva.GetVestingCoins(blockTime))
+	return pva.LockedCoinsFromVesting(pva.GetVestingCoins(blockTime))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -446,7 +446,7 @@ func (dva DelayedVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (dva DelayedVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return dva.BaseVestingAccount.LockedCoinsFromVesting(dva.GetVestingCoins(blockTime))
+	return dva.LockedCoinsFromVesting(dva.GetVestingCoins(blockTime))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -502,7 +502,7 @@ func (plva PermanentLockedAccount) GetVestingCoins(_ time.Time) sdk.Coins {
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (plva PermanentLockedAccount) LockedCoins(_ time.Time) sdk.Coins {
-	return plva.BaseVestingAccount.LockedCoinsFromVesting(plva.OriginalVesting)
+	return plva.LockedCoinsFromVesting(plva.OriginalVesting)
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -604,7 +604,7 @@ func (cva CliffVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins {
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
 func (cva CliffVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return cva.BaseVestingAccount.LockedCoinsFromVesting(cva.GetVestingCoins(blockTime))
+	return cva.LockedCoinsFromVesting(cva.GetVestingCoins(blockTime))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate


### PR DESCRIPTION
Adopt [golangci-lint](https://golangci-lint.run/) v2.0 - because it’s cute, strict, and just wants the best for our code.
Applied [config migration](https://golangci-lint.run/product/migration-guide) and updated codebase to comply with the new linter rules.