### PR TITLE
build(deps): bump golangci-lint from v2.0 to v2.1.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
-          version: v2.0
+          version: v2.1.6
 
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LEDGER_ENABLED         ?= true
 
 # Docker images
 DOCKER_IMAGE_GOLANG	      = golang:1.23-alpine3.20
-DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v2.0
+DOCKER_IMAGE_GOLANG_CI    = golangci/golangci-lint:v2.1.6
 DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_IMAGE_BUF          = bufbuild/buf:1.4.0
 DOCKER_PROTO_RUN         := docker run --rm --user $(id -u):$(id -g) -v $(HOME)/.cache:/root/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the linting tool to a newer version in both the GitHub Actions workflow and the Makefile to ensure improved code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->