### PR TITLE
Switch golangci-lint from docker image to local binary

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,14 @@ linters:
         path: _test\.go
         text: "dot-imports:"
       - linters:
+          - revive
+        path: "util/*"
+        text: "var-naming: avoid meaningless package names"
+      - linters:
+          - revive
+        path: "types/*"
+        text: "var-naming: avoid meaningless package names"
+      - linters:
           - cyclop
         path: (.+)_test\.go
     paths:

--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Targets:
     release-assets      Generate release assets
   Dependencies:
     deps                Install all the dependencies (tools, etc.)
-    deps-tparse         Install tparse v0.16.0 (github.com/mfridman/tparse@v0.16.0)
-    deps-heighliner     Install heighliner v1.7.1 (github.com/strangelove-ventures/heighliner@v1.7.1)
+    deps-tparse         Install tparse (v0.17.0)
+    deps-heighliner     Install heighliner (v1.7.4)
+    deps-cosmovisor     Install cosmovisor (v1.7.1)
+    deps-golangci-lint  Install golangci-lint (v2.4.0)
   Help:
     help                Show this help.
 

--- a/go.mod
+++ b/go.mod
@@ -114,8 +114,8 @@ require (
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/bytedance/sonic v1.13.1 // indirect
-	github.com/bytedance/sonic/loader v0.2.4 // indirect
+	github.com/bytedance/sonic v1.14.0 // indirect
+	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -354,9 +354,13 @@ github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1
 github.com/bytedance/sonic v1.8.0/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
 github.com/bytedance/sonic v1.13.1 h1:Jyd5CIvdFnkOWuKXr+wm4Nyk2h0yAFsr8ucJgEasO3g=
 github.com/bytedance/sonic v1.13.1/go.mod h1:o68xyaF9u2gvVBuGHPlUVCy+ZfmNNO5ETf1+KgkJhz4=
+github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
+github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
+github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=


### PR DESCRIPTION
Switch [golangci-lint](https://golangci-lint.run) from _docker_ image to _local binary_.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Chores
  - Switched Go linting to use a locally installed golangci-lint binary with an automated install target, simplifying setup and speeding up lint runs.
  - Added stricter lint rules to enforce meaningful package names in non-test code.
  - Updated developer help text for tool installation targets.

- Dependencies
  - Upgraded indirect JSON parsing libraries to newer versions for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->