### PR TITLE
Ci/go mod tidy check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: |
+            go.sum
 
       - name: Build go project
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,17 @@ jobs:
         with:
           version: v2.1.6
 
+      - name: Verify Go modules are tidy
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        run: |
+          go mod tidy
+          if ! git diff --quiet -- go.mod go.sum; then
+            echo "❌ go.mod or go.sum are out of date"
+            git --no-pager diff -- go.mod go.sum
+            exit 1
+          fi
+          echo "✅ go.mod and go.sum are tidy"
+
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,7 +100,9 @@ jobs:
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
           go-version-file: 'go.mod'
-          cache: false
+          cache: true
+          cache-dependency-path: |
+            go.sum
 
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v8
@@ -171,6 +173,9 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: |
+            go.sum
 
       - name: Generate command documentation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: |
+            go.sum
 
       - name: Restore Cache for Tools
         uses: actions/cache@v4
@@ -81,6 +84,9 @@ jobs:
         uses: actions/setup-go@v6.0.0
         with:
           go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: |
+            go.sum
 
       - name: Install AXONE blockchain
         run: |


### PR DESCRIPTION
- add a `go mod tidy` guard to the Go lint job so CI fails when `go.mod`/`go.sum` drift.
- also, turn on Go module caching for every [actions/setup-go](https://github.com/actions/setup-go) step to speed _lint_, _test_, and _build_ workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Accelerated CI by enabling Go module caching across build, lint, and test workflows (caches based on go.sum).
  * Added a lint step to verify dependencies are tidy, failing with clear diffs when go.mod or go.sum are out of date.
  * Improves pipeline speed, consistency, and reliability.
  * No changes to app behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->