### PR TITLE
🏗️ Ci/attest docker images

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -29,6 +29,12 @@ concurrency:
 
 jobs:
   publish-docker-images:
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
@@ -66,10 +72,21 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
 
       - name: Build and publish image(s)
+        id: docker_build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
           push: true
+          sbom: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
+
+      - name: Attest release image provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ make install
 docker run -ti --rm axoneprotocol/axoned --help
 ```
 
+Release images published to GHCR and Docker Hub include an SPDX software bill of materials (SBOM) and SLSA build
+provenance. The provenance of a GHCR release image is also signed by GitHub Actions and can be verified against this
+repository:
+
+```sh
+AXONED_IMAGE=ghcr.io/axone-protocol/axoned:X.Y.Z
+docker login ghcr.io
+gh attestation verify "oci://${AXONED_IMAGE}" --repo axone-protocol/axoned
+```
+
+The SBOM and build provenance attached to an image can be inspected with Docker Buildx:
+
+```sh
+docker buildx imagetools inspect "${AXONED_IMAGE}" --format '{{ json .SBOM }}'
+docker buildx imagetools inspect "${AXONED_IMAGE}" --format '{{ json .Provenance }}'
+```
+
 ## Developing & contributing
 
 `axoned` is written in [Go] and built using [Cosmos SDK]. A number of smart contracts are also deployed on the


### PR DESCRIPTION
Adds an `SPDX` `SBOM` and `SLSA` provenance to our Docker images, plus a signed GitHub attestation for releases.
Node binaries are part of the chain's trust surface, so anyone can now inspect what's inside an image and verify where it came from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release container images now include SPDX software bills of materials (SBOMs) and SLSA build provenance.
  * Added support for verifying image attestations and inspecting SBOM and provenance metadata.

* **Documentation**
  * Updated Docker usage guidance with commands for validating image security metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->