### PR TITLE
🏗️ build(project): attest published binaries (SPDX SBOMs)

### DIFF
--- a/.github/workflows/build-docker-heighliner.yml
+++ b/.github/workflows/build-docker-heighliner.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build docker image for Heighliner
         run: |

--- a/.github/workflows/build-docker-local.yml
+++ b/.github/workflows/build-docker-local.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build docker image
         run: |

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/build-proto.yml
+++ b/.github/workflows/build-proto.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build and generate proto
         run: |

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check commits
         uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint dockerfile (hadolint)
         uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0

--- a/.github/workflows/lint-generated-mdx.yml
+++ b/.github/workflows/lint-generated-mdx.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node environment
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6

--- a/.github/workflows/lint-generated.yml
+++ b/.github/workflows/lint-generated.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0

--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint GitHub Actions workflows
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0

--- a/.github/workflows/lint-json.yml
+++ b/.github/workflows/lint-json.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint json files
         run: |

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint regular markdown files
         uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0

--- a/.github/workflows/lint-proto.yml
+++ b/.github/workflows/lint-proto.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint shell scripts
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0

--- a/.github/workflows/lint-typos.yml
+++ b/.github/workflows/lint-typos.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install codespell
         run: |

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Lint yaml files
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1

--- a/.github/workflows/publish-buf-proto.yml
+++ b/.github/workflows/publish-buf-proto.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup buf
         uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4

--- a/.github/workflows/publish-dockerhub-description.yml
+++ b/.github/workflows/publish-dockerhub-description.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
 
       - name: Resolve release version
         id: release

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,83 @@
+name: Release / Assets
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  release-assets:
+    if: startsWith(github.event.release.tag_name, 'v')
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Resolve release version
+        id: release
+        run: echo "version=$(cat version)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build release assets
+        run: make release-assets
+
+      - name: Generate amd64 binary SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: target/release/axoned-${{ steps.release.outputs.version }}-linux-amd64
+          format: spdx-json
+          output-file: target/release/axoned-${{ steps.release.outputs.version }}-linux-amd64.spdx.json
+          syft-version: v1.51.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate arm64 binary SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: target/release/axoned-${{ steps.release.outputs.version }}-linux-arm64
+          format: spdx-json
+          output-file: target/release/axoned-${{ steps.release.outputs.version }}-linux-arm64.spdx.json
+          syft-version: v1.51.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Regenerate release checksums
+        run: make release-checksums
+
+
+      - name: Attest release artifact provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: target/release/sha256sum.txt
+
+      - name: Attest amd64 binary SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: target/release/axoned-${{ steps.release.outputs.version }}-linux-amd64
+          sbom-path: target/release/axoned-${{ steps.release.outputs.version }}-linux-amd64.spdx.json
+
+      - name: Attest arm64 binary SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: target/release/axoned-${{ steps.release.outputs.version }}-linux-arm64
+          sbom-path: target/release/axoned-${{ steps.release.outputs.version }}-linux-arm64.spdx.json
+
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" target/release/* --clobber

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Resolve release context
         run: |

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
       - name: Release project
         uses: cycjimmy/semantic-release-action@ba330626c4750c19d8299de843f05c7aa5574f62 # v5.0.2
         with:

--- a/.github/workflows/social-thank-godeps.yml
+++ b/.github/workflows/social-thank-godeps.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Give thanks!
         run: |

--- a/.github/workflows/test-blockchain.yml
+++ b/.github/workflows/test-blockchain.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends jq

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -42,17 +42,8 @@ plugins:
   - - "@semantic-release/exec"
     - prepareCmd: |
         ./scripts/bump-module.sh
-  - - "@semantic-release/exec"
-    - prepareCmd: |
-        make release-assets
   - - "@semantic-release/github"
     - successComment: false
-      assets:
-        - path: "./target/release/axoned-*-linux-amd64"
-        - path: "./target/release/axoned-*-linux-amd64.tar.gz"
-        - path: "./target/release/axoned-*-linux-arm64"
-        - path: "./target/release/axoned-*-linux-arm64.tar.gz"
-        - path: "./target/release/sha256sum.txt"
   - - "@semantic-release/git"
     - assets:
         - README.md

--- a/Makefile
+++ b/Makefile
@@ -469,9 +469,10 @@ $(RELEASE_TARGETS): ensure-buildx-builder
 
 release-checksums:
 	@${call echo_msg, 🔑, Generating, release binary ${COLOR_YELLOW}checksums}
-	@rm ${RELEASE_FOLDER}/sha256sum.txt; \
-	for asset in `ls ${RELEASE_FOLDER}`; do \
-		shasum -a 256 ${RELEASE_FOLDER}/$$asset >> ${RELEASE_FOLDER}/sha256sum.txt; \
+	@rm -f ${RELEASE_FOLDER}/sha256sum.txt; \
+	cd ${RELEASE_FOLDER}; \
+	for asset in *; do \
+		shasum -a 256 "$$asset" >> sha256sum.txt; \
 	done;
 
 ensure-buildx-builder:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ All releases can be found [here](https://github.com/axone-protocol/axoned/releas
 `axoned` follows the [Semantic Versioning 2.0.0](https://semver.org/) to determine when and how the version changes, and
 we also apply the philosophical principles of [release early - release often](https://en.wikipedia.org/wiki/Release_early,_release_often).
 
+Newly published release binaries are accompanied by an SPDX SBOM and signed SLSA provenance. A downloaded binary can be
+verified against this repository:
+
+```sh
+gh attestation verify ./axoned-X.Y.Z-linux-amd64 --repo axone-protocol/axoned
+```
+
 ## Install
 
 ### From release


### PR DESCRIPTION
Following #1200, publish signed SLSA provenance and SPDX SBOMs with release binaries so users (and more specifically validators) can verify that downloaded artifacts originate from this repository and were not altered. See: [use-artifact-attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations).

This strengthens distribution-chain integrity and traceability: attestations are generated for the exact artifacts delivered with each release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release binaries now include SPDX software bills of materials (SBOMs).
  * Releases include signed provenance attestations for improved supply-chain verification.
  * Release assets are automatically published for supported Linux architectures.

* **Documentation**
  * Added instructions for verifying downloaded binaries and their attestations using GitHub CLI.

* **Bug Fixes**
  * Improved checksum generation to reliably reference released assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->