### PR TITLE
build(project): manage development tools in the flake

### DIFF
--- a/.github/workflows/build-docker-heighliner.yml
+++ b/.github/workflows/build-docker-heighliner.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/build-docker-heighliner.yml'
+      - flake.lock
+      - flake.nix
       - '.heighliner/**'
       - 'app/**'
       - 'cmd/**'
@@ -20,6 +22,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/build-docker-heighliner.yml'
+      - flake.lock
+      - flake.nix
       - '.heighliner/**'
       - 'app/**'
       - 'cmd/**'
@@ -47,6 +51,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
       - name: Build docker image for Heighliner
-        run: |
-          make build-docker
+        run: nix develop --command make build-docker

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ LEDGER_ENABLED         ?= true
 TARGET_FOLDER           = target
 DIST_FOLDER             = $(TARGET_FOLDER)/dist
 RELEASE_FOLDER          = $(TARGET_FOLDER)/release
-TOOLS_FOLDER            = $(TARGET_FOLDER)/tools
 E2E_PKG_FOLDER         ?= ./x/logic/tests/...
 COVER_UNIT_FILE        := $(TARGET_FOLDER)/coverage.unit.txt
 COVER_E2E_FILE         := $(TARGET_FOLDER)/coverage.e2e.txt
@@ -21,16 +20,6 @@ DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_PROTO_RUN         := docker run --rm --user $(shell id -u):$(shell id -g) -e HOME=/tmp -e GOPATH=/tmp/go -e GOBIN=/tmp/go/bin -v $(HOME)/.cache:/tmp/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)
 DOCKER_BUILDX_BUILDER     = axone-builder
 
-# Tools
-TOOL_HEIGHLINER_NAME     := heighliner
-TOOL_HEIGHLINER_VERSION  := v1.7.4
-TOOL_HEIGHLINER_PKG      := github.com/strangelove-ventures/$(TOOL_HEIGHLINER_NAME)@$(TOOL_HEIGHLINER_VERSION)
-TOOL_HEIGHLINER_BIN      := ${TOOLS_FOLDER}/$(TOOL_HEIGHLINER_NAME)/$(TOOL_HEIGHLINER_VERSION)/$(TOOL_HEIGHLINER_NAME)
-
-TOOL_COSMOVISOR_NAME     := cosmovisor
-TOOL_COSMOVISOR_VERSION  := v1.7.1
-TOOL_COSMOVISOR_PKG      := cosmossdk.io/tools/$(TOOL_COSMOVISOR_NAME)/cmd/$(TOOL_COSMOVISOR_NAME)@$(TOOL_COSMOVISOR_VERSION)
-TOOL_COSMOVISOR_BIN      := ${TOOLS_FOLDER}/$(TOOL_COSMOVISOR_NAME)/$(TOOL_COSMOVISOR_VERSION)/$(TOOL_COSMOVISOR_NAME)
 
 # Coverage settings
 COVERPKG := $(shell go list ./x/logic/... | grep -v '/tests/' | tr '\n' ',' | sed 's/,$$//')
@@ -198,9 +187,9 @@ build-go: ## Build node executable for the current environment (default build)
 build-go-all: $(ENVIRONMENTS_TARGETS) ## Build node executables for all available environments
 
 .PHONY: build-docker
-build-docker: $(TOOL_HEIGHLINER_BIN) ## Build docker image
+build-docker: ## Build docker image
 	@${call echo_msg, 🐳, Building, docker image,...}
-	@$(TOOL_HEIGHLINER_BIN) build -c axone --local -f .heighliner/chains.yaml
+	@heighliner build -c axone --local -f .heighliner/chains.yaml
 
 $(ENVIRONMENTS_TARGETS):
 	@GOOS=$(word 3, $(subst -, ,$@)); \
@@ -320,9 +309,9 @@ chain-stop: ## Stop the blockchain
 	@killall axoned
 
 .PHONY: chain-upgrade
-chain-upgrade: build-go deps-$(TOOL_COSMOVISOR_NAME) ## Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION.
+chain-upgrade: build-go ## Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION.
 	@${call echo_msg, 🔄, Upgrading, chain ${CHAIN}, from ${COLOR_YELLOW}${FROM_VERSION} to ${COLOR_YELLOW}${TO_VERSION}}
-	@killall $(TOOL_COSMOVISOR_BIN) || \
+	@killall cosmovisor 2>/dev/null || true; \
 	rm -rf ${TARGET_FOLDER}/${FROM_VERSION}; \
 	git clone -b ${FROM_VERSION} https://$(MODULE_AXONED).git ${TARGET_FOLDER}/${FROM_VERSION}; \
 	${call echo_msg, 🏗️, Building, binary,  ${COLOR_YELLOW}${FROM_VERSION}}; \
@@ -332,14 +321,14 @@ chain-upgrade: build-go deps-$(TOOL_COSMOVISOR_NAME) ## Test the chain upgrade f
 	cd ../../; \
 	make chain-init CHAIN_BINARY=$$BINARY_OLD; \
 	\
-	${call echo_msg, 👩‍🚀, Preparing, $(TOOL_COSMOVISOR_BIN)}; \
+	${call echo_msg, 👩‍🚀, Preparing, cosmovisor}; \
 	export DAEMON_NAME=${DAEMON_NAME}; \
 	export DAEMON_HOME=${DAEMON_HOME}; \
 	\
 	cat <<< $$(jq '.app_state.gov.params.voting_period = "20s"' ${CHAIN_HOME}/config/genesis.json) > ${CHAIN_HOME}/config/genesis.json; \
 	\
-	$(TOOL_COSMOVISOR_BIN) init $$BINARY_OLD; \
-	$(TOOL_COSMOVISOR_BIN) run start --moniker ${CHAIN_MONIKER} \
+	cosmovisor init $$BINARY_OLD; \
+	cosmovisor run start --moniker ${CHAIN_MONIKER} \
 		--home ${DAEMON_HOME} \
 		--log_level debug & \
 	sleep 10; \
@@ -406,8 +395,7 @@ doc-command: ## Generate markdown documentation for the command
 	@${call echo_msg, 📖, Generating, documentation, for the CLI}
 	@OUT_FOLDER="docs/command"; \
 	rm -rf $$OUT_FOLDER; \
-	go get ./scripts; \
-	go run ./scripts/. command; \
+	go run -mod=readonly ./scripts/. command; \
 	$(SED_INPLACE) 's/(default \"\/.*\/\.axoned\")/(default \"\/home\/john\/\.axoned\")/g' $$OUT_FOLDER/*.md; \
 	$(SED_INPLACE) 's/node\ name\ (default\ \".*\")/node\ name\ (default\ \"my-machine\")/g' $$OUT_FOLDER/*.md; \
 	$(SED_INPLACE) 's/IP\ (default\ \".*\")/IP\ (default\ \"127.0.0.1\")/g' $$OUT_FOLDER/*.md; \
@@ -432,7 +420,6 @@ doc-predicate: ## Generate markdown documentation for all the predicates (module
 .PHONY: mock
 mock: ## Generate all the mocks (for tests)
 	@${call echo_msg, 🧱, Generating, mocks}
-	@go install go.uber.org/mock/mockgen@v0.5.0
 	@mockgen -source=x/mint/types/expected_keepers.go -package testutil -destination x/mint/testutil/expected_keepers_mocks.go
 	@mockgen -source=x/vesting/types/expected_keepers.go -package testutil -destination x/vesting/testutil/expected_keepers_mocks.go
 	@mockgen -source=x/logic/types/expected_keepers.go -package testutil -destination x/logic/testutil/expected_keepers_mocks.go
@@ -480,34 +467,6 @@ ensure-buildx-builder:
 	@docker buildx ls | sed '1 d' | cut -f 1 -d ' ' | grep -q ${DOCKER_BUILDX_BUILDER} || \
 	docker buildx create --name ${DOCKER_BUILDX_BUILDER}
 
-## Dependencies:
-.PHONY: deps
-deps: deps-$(TOOL_HEIGHLINER_NAME) deps-$(TOOL_COSMOVISOR_NAME) ## Install all the dependencies (tools, etc.)
-
-.PHONY: deps-$(TOOL_HEIGHLINER_NAME)
-deps-heighliner: $(TOOL_HEIGHLINER_BIN) ## Install $TOOL_HEIGHLINER_NAME ($TOOL_HEIGHLINER_VERSION)
-
-.PHONY: deps-$(TOOL_COSMOVISOR_NAME)
-deps-cosmovisor: $(TOOL_COSMOVISOR_BIN) ## Install $TOOL_COSMOVISOR_NAME ($TOOL_COSMOVISOR_VERSION)
-
-$(TOOL_HEIGHLINER_BIN):
-	@${call echo_msg, 📦, Installing, $(TOOL_HEIGHLINER_NAME)@$(TOOL_HEIGHLINER_VERSION),...}
-	@mkdir -p $(dir $(TOOL_HEIGHLINER_BIN))
-	CUR_DIR=$(shell pwd) && \
-	TEMP_DIR=$(shell mktemp -d) && \
-	GIT_URL=https://$(firstword $(subst @, ,$(TOOL_HEIGHLINER_PKG))).git && \
-	GIT_TAG=$(word 2,$(subst @, ,$(TOOL_HEIGHLINER_PKG))) && \
-	git clone --branch $$GIT_TAG --depth 1 $$GIT_URL $$TEMP_DIR && \
-	cd $$TEMP_DIR && \
-	make build && \
-	cd $$CUR_DIR && \
-	mv $$TEMP_DIR/heighliner $(TOOL_HEIGHLINER_BIN) && \
-	rm -rf $$TEMP_DIR
-
-$(TOOL_COSMOVISOR_BIN):
-	@${call echo_msg, 📦, Installing, $(TOOL_COSMOVISOR_NAME)@$(TOOL_COSMOVISOR_VERSION),...}
-	@mkdir -p $(dir $(TOOL_COSMOVISOR_BIN))
-	@GOBIN=$(dir $(abspath $(TOOL_COSMOVISOR_BIN))) go install $(TOOL_COSMOVISOR_PKG)
 
 ## Help:
 .PHONY: help
@@ -517,16 +476,12 @@ help: ## Show this help.
 	@echo '  ${COLOR_YELLOW}make${COLOR_RESET} ${COLOR_GREEN}<target>${COLOR_RESET}'
 	@echo ''
 	@echo 'Targets:'
-	@$(foreach V,$(sort $(.VARIABLES)), \
-		$(if $(filter-out environment% default automatic,$(origin $V)), \
-			$(if $(filter TOOL_%,$V), \
-				export $V="$($V)";))) \
-	awk 'BEGIN {FS = ":.*?## "} { \
+	@awk 'BEGIN {FS = ":.*?## "} { \
 		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "    ${COLOR_YELLOW}%-20s${COLOR_GREEN}%s${COLOR_RESET}\n", $$1, $$2} \
 		else if (/^## .*$$/) {printf "  ${COLOR_CYAN}%s${COLOR_RESET}\n", substr($$1,4)} \
 		}' $(MAKEFILE_LIST) | envsubst
 	@echo ''
-	@echo 'This Makefile requires ${COLOR_CYAN}nix${COLOR_RESET} for development tools. Run ${COLOR_YELLOW}nix develop${COLOR_RESET} to enter the dev shell.'
+	@echo 'This Makefile requires Nix for development tools. Run ${COLOR_YELLOW}direnv allow${COLOR_RESET} once, or ${COLOR_YELLOW}nix develop${COLOR_RESET} before invoking Make.'
 	@echo 'Docker is only needed for ${COLOR_YELLOW}proto-gen${COLOR_RESET} and ${COLOR_YELLOW}release builds${COLOR_RESET}.'
 
 # $(call echo_msg, <emoji>, <action>, <object>, <context>)

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ AXONE blockchain and hosted in the [axone-protocol/contracts](https://github.com
 
 ### Prerequisites
 
-- install [Go] `1.25+` following instructions from the [official Go documentation](https://golang.org/doc/install);
-- use [gofumpt](https://github.com/mvdan/gofumpt) as formatter. You can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation) or invoke the makefile `make format-go`;
-- verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
-- verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed if you intend to use the provided `Makefile`.
+- install [Nix](https://nixos.org/download/);
+- install [direnv](https://direnv.net/) and [nix-direnv](https://github.com/nix-community/nix-direnv), then run `direnv allow` from the repository root;
+- without `direnv`, enter the development shell with `nix develop` before invoking `make`;
+- verify that [Docker] is properly installed and running if you use Docker-related targets.
 
 ### Makefile
 
@@ -172,16 +172,10 @@ Targets:
     mock                Generate all the mocks (for tests)
   Release:
     release-assets      Generate release assets
-  Dependencies:
-    deps                Install all the dependencies (tools, etc.)
-    deps-heighliner     Install heighliner (v1.7.4)
-    deps-cosmovisor     Install cosmovisor (v1.7.1)
-    deps-golangci-lint  Install golangci-lint (v2.10.1)
-    deps-gofumpt        Install gofumpt (v0.9.2)
   Help:
     help                Show this help.
 
-This Makefile depends on docker. To install it, please follow the instructions:
+This Makefile uses tools provided by the Nix development environment. Docker remains a host dependency:
 - for macOS: https://docs.docker.com/docker-for-mac/install/
 - for Windows: https://docs.docker.com/docker-for-windows/install/
 - for Linux: https://docs.docker.com/engine/install/
@@ -199,8 +193,8 @@ The binary will be generated under the folder `target/dist`.
 
 ### Build a docker image
 
-This project leverages [heighliner](https://github.com/strangelove-ventures/heighliner) to simplify the management and
-creation of production-grade container images. To build a Docker image, use the `build-docker` target in the `Makefile`:
+This project leverages [heighliner](https://github.com/strangelove-ventures/heighliner), provided by the Nix development
+environment, to simplify the management and creation of production-grade container images:
 
 ```sh
 make build-docker

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,56 @@
 {
   "nodes": {
+    "cosmovisor": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739377715,
+        "narHash": "sha256-ys4WwzX/JY9lEDyw+Ia3g/gikz6//Cpla1KjX4TbPEc=",
+        "owner": "cosmos",
+        "repo": "cosmos-sdk",
+        "rev": "f072ecaba61468d7bad864b92721116f72d4e8a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cosmos",
+        "ref": "tools/cosmovisor/v1.7.1",
+        "repo": "cosmos-sdk",
+        "type": "github"
+      }
+    },
+    "heighliner": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752268462,
+        "narHash": "sha256-qfmsmbYL4C3JRskrJENt672ZxmxmlUD+z74f8AwRm5M=",
+        "owner": "strangelove-ventures",
+        "repo": "heighliner",
+        "rev": "fa0a3452afcaaa5ef1a0de53a860c7af92454447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "strangelove-ventures",
+        "ref": "v1.7.4",
+        "repo": "heighliner",
+        "type": "github"
+      }
+    },
+    "mock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755529084,
+        "narHash": "sha256-gYUL+ucnKQncudQDcRt8aDqM7xE5XSKHh4X0qFrvfGs=",
+        "owner": "uber",
+        "repo": "mock",
+        "rev": "2d1c58167e30f380cf78e44a43b100a14767e817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "uber",
+        "ref": "v0.6.0",
+        "repo": "mock",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780453794,
@@ -16,9 +67,29 @@
         "type": "github"
       }
     },
+    "nixpkgsGo124": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "cosmovisor": "cosmovisor",
+        "heighliner": "heighliner",
+        "mock": "mock",
+        "nixpkgs": "nixpkgs",
+        "nixpkgsGo124": "nixpkgsGo124"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,32 @@
   description = "AXONE Protocol blockchain development environment";
 
   inputs = {
+    cosmovisor = {
+      url = "github:cosmos/cosmos-sdk/tools/cosmovisor/v1.7.1";
+      flake = false;
+    };
+    heighliner = {
+      url = "github:strangelove-ventures/heighliner/v1.7.4";
+      flake = false;
+    };
+    mock = {
+      url = "github:uber/mock/v0.6.0";
+      flake = false;
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    nixpkgsGo124.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
   outputs =
-    { nixpkgs, ... }:
+    {
+      self,
+      cosmovisor,
+      heighliner,
+      mock,
+      nixpkgs,
+      nixpkgsGo124,
+      ...
+    }:
     let
       supportedSystems = [
         "aarch64-darwin"
@@ -17,6 +38,38 @@
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          go124 = nixpkgsGo124.legacyPackages.${system}.go_1_24;
+        in
+        {
+          cosmovisor = (pkgs.buildGoModule.override { go = go124; }) {
+            pname = "cosmovisor";
+            version = "1.7.1";
+            src = cosmovisor;
+            modRoot = "tools/cosmovisor";
+            subPackages = [ "cmd/cosmovisor" ];
+            env.CGO_ENABLED = 0;
+            vendorHash = "sha256-DXgFvjm1fDHtDwPNfLIPi2vMdZTi3bYN7cgR1dgdgLk=";
+          };
+          heighliner = pkgs.buildGoModule {
+            pname = "heighliner";
+            version = "1.7.4";
+            src = heighliner;
+            vendorHash = "sha256-Sa/lCa7IFcnIGNKCPvFeQke6dNOycK6vjg5gmHOOdic=";
+          };
+          mockgen = pkgs.buildGoModule {
+            pname = "mockgen";
+            version = "0.6.0";
+            src = mock;
+            subPackages = [ "mockgen" ];
+            vendorHash = "sha256-Cf7lKfMuPFT/I1apgChUNNCG2C7SrW7ncF8OusbUs+A=";
+          };
+        }
+      );
+
       devShells = forAllSystems (
         system:
         let
@@ -25,6 +78,9 @@
         {
           default = pkgs.mkShell {
             packages = [
+              self.packages.${system}.cosmovisor
+              self.packages.${system}.heighliner
+              self.packages.${system}.mockgen
               pkgs.act
               pkgs.actionlint
               pkgs.bash-language-server


### PR DESCRIPTION
Following #1160, move [Heighliner](https://github.com/strangelove-ventures/heighliner), [Cosmovisor](https://github.com/cosmos/cosmos-sdk/blob/main/tools/cosmovisor/README.md), and [Mockgen](https://github.com/uber/mock/) provisioning from the Makefile into pinned Nix derivations. The development shell now provides these tools, Make targets consume them from PATH, and the Heighliner CI job runs inside the Nix environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Development Experience**
  * Standardized project setup and build commands through a Nix development environment.
  * Added pinned development tools for chain upgrades, Docker builds, and mock generation.
  * Simplified local tool management by removing manual installation steps.

* **Documentation**
  * Updated installation, development, and build instructions to reflect the Nix-based workflow.

* **CI**
  * Docker builds now run through the Nix environment and automatically respond to Nix configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->